### PR TITLE
chore: remove unused type mapping fields from templates

### DIFF
--- a/registry-v2/1-business/products/_template.md
+++ b/registry-v2/1-business/products/_template.md
@@ -24,7 +24,6 @@ aggregates_business_services: []
 # ── Alignment ────────────────────────────────────────────────
 archimate_type: product
 togaf_type: Product
-capsifi_type: Product
 software_boundaries: Digital Product Solution
 ---
 

--- a/registry-v2/2-organization/actors/_template.md
+++ b/registry-v2/2-organization/actors/_template.md
@@ -18,7 +18,6 @@ actor_type: internal | external | system
 archimate_type: business-actor
 togaf_type: Actor
 uml_type: Actor
-capsifi_type: ~
 ---
 
 # <Actor Name>

--- a/registry-v2/2-organization/capabilities/_template.md
+++ b/registry-v2/2-organization/capabilities/_template.md
@@ -26,7 +26,6 @@ realized_by_components: []
 # ── Alignment ────────────────────────────────────────────────
 archimate_type: business-function
 togaf_type: Business Capability
-capsifi_type: Business Capability
 ---
 
 # <Business Capability Name>

--- a/registry-v2/2-organization/capabilities/customer-management.md
+++ b/registry-v2/2-organization/capabilities/customer-management.md
@@ -16,7 +16,6 @@ realized_by_components:
 
 archimate_type: business-function
 togaf_type: Business Capability
-capsifi_type: Business Capability
 ---
 
 # Customer Management

--- a/registry-v2/2-organization/organisation-units/_template.md
+++ b/registry-v2/2-organization/organisation-units/_template.md
@@ -33,7 +33,6 @@ owns_e2e_processes: []
 # ── Alignment ────────────────────────────────────────────────
 archimate_type: business-actor
 togaf_type: Organization Unit
-capsifi_type: Organisation
 ---
 
 <!-- Extended description, org chart, responsibilities, etc. -->

--- a/registry-v2/2-organization/roles/_template.md
+++ b/registry-v2/2-organization/roles/_template.md
@@ -22,7 +22,6 @@ performs_process_tasks: []
 # ── Alignment ────────────────────────────────────────────────
 archimate_type: business-role
 togaf_type: Role
-capsifi_type: Role
 ---
 
 <!-- Extended description, responsibilities, permissions, etc. -->

--- a/registry-v2/2-organization/value-streams/_template.md
+++ b/registry-v2/2-organization/value-streams/_template.md
@@ -22,7 +22,6 @@ owned_by_organisation_units: []
 # ── Alignment ────────────────────────────────────────────────
 archimate_type: business-process
 togaf_type: Value Stream
-capsifi_type: Value Stream
 ---
 
 <!-- Extended description, outcomes, metrics, stages, etc. -->

--- a/registry-v2/3-application/api-contracts/_template.md
+++ b/registry-v2/3-application/api-contracts/_template.md
@@ -25,8 +25,6 @@ archimate_type: application-service
 ddd_type: Domain Service
 togaf_type: Information System Service
 emm_type: Conceptual IS Service
-software_boundaries_type: Software Component
-capsifi_type: ~
 ---
 
 <!-- Extended description, operations, versioning -->

--- a/registry-v2/3-application/api-endpoints/_template.md
+++ b/registry-v2/3-application/api-endpoints/_template.md
@@ -35,8 +35,6 @@ uml_type: Interface
 ddd_type: Application Service
 togaf_type: Information System Service
 emm_type: ~
-software_boundaries_type: Software Component
-capsifi_type: ~
 ---
 
 <!-- Extended description, endpoints, authentication, versioning -->

--- a/registry-v2/3-application/components/_template.md
+++ b/registry-v2/3-application/components/_template.md
@@ -38,8 +38,6 @@ archimate_type: application-function
 ddd_type: Bounded Context
 togaf_type: Information System Service
 emm_type: Logical IS Component
-software_boundaries_type: ~
-capsifi_type: Logical Applications
 ---
 
 <!-- Extended description, boundaries, responsibilities -->

--- a/registry-v2/3-application/data-aggregates/_template.md
+++ b/registry-v2/3-application/data-aggregates/_template.md
@@ -33,7 +33,6 @@ archimate_type: data-object
 ddd_type: Aggregate
 togaf_type: Logical Data Component
 emm_type: ~
-capsifi_type: System
 c4_type: ~
 ---
 

--- a/registry-v2/3-application/data-concepts/_template.md
+++ b/registry-v2/3-application/data-concepts/_template.md
@@ -30,7 +30,6 @@ realizes_business_information_object:
 archimate_type: data-object
 togaf_type: Data Entities
 emm_type: Data Concept
-capsifi_type: Concept
 ddd_type: ~
 c4_type: ~
 ---

--- a/registry-v2/3-application/data-entities/_template.md
+++ b/registry-v2/3-application/data-entities/_template.md
@@ -33,7 +33,6 @@ archimate_type: data-object
 ddd_type: Entity
 togaf_type: Physical Data Component
 emm_type: Data Entity
-capsifi_type: ~
 c4_type: ~
 ---
 

--- a/registry-v2/3-application/domain-events/_template.md
+++ b/registry-v2/3-application/domain-events/_template.md
@@ -31,7 +31,6 @@ c4_type: Relation
 ddd_type: Domain Event
 togaf_type: ~
 emm_type: ~
-capsifi_type: ~
 ---
 
 <!-- Extended description, payload schema, versioning, etc. -->

--- a/registry-v2/3-application/domains/_template.md
+++ b/registry-v2/3-application/domains/_template.md
@@ -25,8 +25,6 @@ archimate_type: application-function
 ddd_type: Domain
 togaf_type: ~
 emm_type: Architecture Area
-software_boundaries_type: Software Domain
-capsifi_type: ~
 ---
 
 <!-- Extended description, scope, boundaries, responsibilities -->

--- a/registry-v2/3-application/software-components/_template.md
+++ b/registry-v2/3-application/software-components/_template.md
@@ -29,8 +29,6 @@ uml_type: Component
 ddd_type: Module
 togaf_type: ~
 emm_type: ~
-software_boundaries_type: Software Component
-capsifi_type: ~
 ---
 
 <!-- Extended description, purpose, technology, etc. -->

--- a/registry-v2/3-application/software-subsystems/_template.md
+++ b/registry-v2/3-application/software-subsystems/_template.md
@@ -39,8 +39,6 @@ c4_type: Container
 uml_type: SubSystem
 togaf_type: Application Component
 emm_type: Physical IS Component
-software_boundaries_type: Software Subsystem
-capsifi_type: ~
 ---
 
 <!-- Extended description, deployment, runtime config -->

--- a/registry-v2/3-application/software-systems/_template.md
+++ b/registry-v2/3-application/software-systems/_template.md
@@ -28,8 +28,6 @@ c4_type: System
 uml_type: System
 togaf_type: Application Component
 emm_type: Physical IS Component
-software_boundaries_type: Business System
-capsifi_type: System
 ddd_type: ~
 ---
 

--- a/registry-v2/4-technology/application-infrastructure/_template.md
+++ b/registry-v2/4-technology/application-infrastructure/_template.md
@@ -33,8 +33,6 @@ archimate_type: system-software
 uml_type: Artifact
 togaf_type: Physical Technology Component
 emm_type: Physical TI Component
-software_boundaries_type: Technology System
-capsifi_type: Technology Component
 ---
 
 <!-- Extended description, vendor info, support, etc. -->

--- a/registry-v2/4-technology/cloud-services/_template.md
+++ b/registry-v2/4-technology/cloud-services/_template.md
@@ -32,8 +32,6 @@ archimate_type: system-software
 uml_type: Artifact
 togaf_type: Physical Technology Component
 emm_type: Physical TI Component
-software_boundaries_type: Technology System
-capsifi_type: Technology Component
 ---
 
 <!-- Extended description, cloud config, contracts, etc. -->

--- a/registry-v2/4-technology/infra-nodes/_template.md
+++ b/registry-v2/4-technology/infra-nodes/_template.md
@@ -36,8 +36,6 @@ archimate_type: node
 uml_type: Node
 togaf_type: Physical Technology Component
 emm_type: Physical TI Component
-software_boundaries_type: Hardware
-capsifi_type: Technology Component
 ---
 
 <!-- Extended description, specs, location, config -->

--- a/registry-v2/4-technology/infrastructure-apis/_template.md
+++ b/registry-v2/4-technology/infrastructure-apis/_template.md
@@ -26,7 +26,6 @@ serves_software_subsystems: []
 archimate_type: technology-service
 togaf_type: Technology Service
 emm_type: Conceptual TI Service
-capsifi_type: ~
 ---
 
 <!-- Extended description, specification, versions, etc. -->

--- a/registry-v2/4-technology/infrastructure-functions/_template.md
+++ b/registry-v2/4-technology/infrastructure-functions/_template.md
@@ -34,7 +34,6 @@ realizes_infrastructure_apis: []
 archimate_type: technology-function
 togaf_type: Logical Technology Component
 emm_type: Logical TI Component
-capsifi_type: ~
 ---
 
 <!-- Extended description, capabilities offered, etc. -->

--- a/registry-v2/4-technology/network-zones/_template.md
+++ b/registry-v2/4-technology/network-zones/_template.md
@@ -27,8 +27,6 @@ archimate_type: communication-network
 uml_type: Communication Path
 togaf_type: Physical Technology Component
 emm_type: Physical TI Component
-software_boundaries_type: Hardware
-capsifi_type: Technology Component
 ---
 
 <!-- Extended description, security controls, firewall rules, etc. -->

--- a/registry-v2/4-technology/networking-equipment/_template.md
+++ b/registry-v2/4-technology/networking-equipment/_template.md
@@ -28,8 +28,6 @@ archimate_type: device
 uml_type: Device
 togaf_type: Physical Technology Component
 emm_type: Physical TI Component
-software_boundaries_type: Hardware
-capsifi_type: Technology Component
 ---
 
 <!-- Extended description, vendor, specs, config, etc. -->


### PR DESCRIPTION
Remove noisy fields from registry templates. These fields are not read by the loader or UI and added unnecessary noise to the frontmatter.