### PR TITLE
feat: add animated edges and remove minimap from graph views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,39 @@ See `docs-site/src/content/docs/contributing/how-to-contribute.md` for detailed 
 
 ---
 
+## Git Workflow
+
+- **Never commit directly to `main`** — branch protection rules are enabled
+- Always create a feature branch from `main`: `git checkout -b <type>/<short-description>`
+- Branch naming: `feat/`, `fix/`, `chore/`, `docs/` prefixes
+- Implement, test, commit on the branch, then push and create a PR
+- Merge via GitHub PR (squash or merge commit)
+
+---
+
+## Maps Architecture
+
+Maps are analytical views that consume registry data. They are a **separate layer** from the core registry schema.
+
+**Two-tier design:**
+
+1. **Core schema (`registry-mapping.yaml`)** — vocabulary-agnostic, drives the registry loader and catalog UI. No type-name conditionals, no layer-name conditionals. A user can rename every type and layer and it still works.
+
+2. **Map definitions (separate YAML files)** — view-specific, can reference specific element types. Each map type gets its own YAML:
+   - `registry-mapping.yaml` → Domain Context Map (uses registry relationships)
+   - `event-mapping.yaml` → Event Flow Map (knows about events, publish/consume)
+   - Future: `heatmap-mapping.yaml`, `impact-mapping.yaml`, etc.
+
+**Why maps are NOT vocabulary-agnostic:** An event map needs to know what events are. A capability heatmap needs to know what capabilities are. These are opinionated analytical views — that's the whole point. The core registry stays generic; map views are intentionally domain-aware.
+
+**Adding a new map type:**
+1. Create a YAML definition file in `models/` (e.g., `heatmap-mapping.yaml`)
+2. Create the React visualization component in `catalog-ui/src/components/graphs/`
+3. Create the Astro page to render it
+4. Pre-configured maps ship with the project; custom maps can be contributed
+
+---
+
 ## Development Principles
 
 - Build incrementally — 1% at a time, prove each piece works

--- a/catalog-ui/src/components/graphs/DomainContextMap.tsx
+++ b/catalog-ui/src/components/graphs/DomainContextMap.tsx
@@ -7,7 +7,6 @@ import {
   ReactFlow,
   Background,
   Controls,
-  MiniMap,
   useNodesState,
   useEdgesState,
   useReactFlow,
@@ -162,8 +161,7 @@ function DomainContextMapInner({ domain, elements }: DomainContextMapProps) {
       backgroundColor: '#fafafa',
       pixelRatio: 2,
       filter: (node) => {
-        // Exclude minimap and controls from the export
-        if (node?.classList?.contains('react-flow__minimap')) return false;
+        // Exclude controls from the export
         if (node?.classList?.contains('react-flow__controls')) return false;
         return true;
       },
@@ -241,14 +239,6 @@ function DomainContextMapInner({ domain, elements }: DomainContextMapProps) {
         >
           <Background color="#e2e8f0" gap={20} />
           <Controls position="top-left" showInteractive={false} />
-          <MiniMap
-            nodeColor={(node) => {
-              const style = (node.data as Record<string, unknown>)?.style as Record<string, string> | undefined;
-              return style?.border || '#94a3b8';
-            }}
-            maskColor="rgba(0,0,0,0.1)"
-            position="bottom-left"
-          />
 
           {/* Toolbar Panel — search, status filter, export */}
           <Panel position="top-right">

--- a/catalog-ui/src/components/graphs/EventFlowGraph.tsx
+++ b/catalog-ui/src/components/graphs/EventFlowGraph.tsx
@@ -8,7 +8,6 @@ import {
   ReactFlow,
   Background,
   Controls,
-  MiniMap,
   useNodesState,
   useEdgesState,
   useReactFlow,
@@ -177,7 +176,6 @@ function EventFlowGraphInner({ eventFlow, domainName }: EventFlowGraphProps) {
       backgroundColor: '#fafafa',
       pixelRatio: 2,
       filter: (node) => {
-        if (node?.classList?.contains('react-flow__minimap')) return false;
         if (node?.classList?.contains('react-flow__controls')) return false;
         return true;
       },
@@ -221,14 +219,6 @@ function EventFlowGraphInner({ eventFlow, domainName }: EventFlowGraphProps) {
       >
         <Background color="#e2e8f0" gap={20} />
         <Controls position="top-left" showInteractive={false} />
-        <MiniMap
-          nodeColor={(node) => {
-            const style = (node.data as Record<string, unknown>)?.style as Record<string, string> | undefined;
-            return style?.border || '#94a3b8';
-          }}
-          maskColor="rgba(0,0,0,0.1)"
-          position="bottom-left"
-        />
 
         {/* Export button */}
         <Panel position="top-right">

--- a/catalog-ui/src/components/graphs/utils/graph-data.ts
+++ b/catalog-ui/src/components/graphs/utils/graph-data.ts
@@ -113,6 +113,7 @@ export function buildDomainGraph(
           source: normalized.source,
           target: normalized.target,
           type: 'relationshipEdge',
+          animated: true,
           data: {
             relationship: rel.type,
             label: semantics.label,
@@ -144,6 +145,7 @@ export function buildDomainGraph(
         source: domain.id,
         target: el.id,
         type: 'relationshipEdge',
+        animated: true,
         data: {
           relationship: 'composition',
           label: 'contains',
@@ -268,6 +270,7 @@ export function buildElementGraph(
       source: normalized.source,
       target: normalized.target,
       type: 'relationshipEdge',
+      animated: true,
       data: {
         relationship: rel.type,
         label: semantics.label,
@@ -320,6 +323,7 @@ export function buildElementGraph(
           source: normalized.source,
           target: normalized.target,
           type: 'relationshipEdge',
+          animated: true,
           data: {
             relationship: rel.type,
             label: semantics.label,


### PR DESCRIPTION
Add flow animation to all relationship edges in domain context map, element context graph, and event flow graph. Remove minimap overlay from both graph views for a cleaner look. Document git workflow and maps architecture strategy in CLAUDE.md.