### PR TITLE
feat: add maps section, domain-scoped capability heatmap with treemap UX

### DIFF
--- a/catalog-ui/src/data/registry.ts
+++ b/catalog-ui/src/data/registry.ts
@@ -30,6 +30,7 @@ import {
 } from '../lib/registry-loader';
 import type { RegistryGraph, SiteConfig, LayerDef, RelationshipTypeDef } from '../lib/types';
 import { loadEventMapping, resolveEventFlows, type EventFlow, type EventMappingConfig } from '../lib/event-mapping-loader';
+import { loadHeatmapMapping, type HeatmapMappingConfig } from '../lib/heatmap-mapping-loader';
 
 // ─────────────────────────────────────────────────────────────
 // Types — self-contained, no dependency on mock.ts
@@ -86,6 +87,7 @@ let _domains: Domain[] = [];
 let _elements: Element[] = [];
 let _loadError: string | null = null;
 let _eventMapping: EventMappingConfig | null = null;
+let _heatmapMapping: HeatmapMappingConfig | null = null;
 const _eventFlowCache = new Map<string, EventFlow | null>();
 
 try {
@@ -130,6 +132,12 @@ try {
   _eventMapping = loadEventMapping();
   if (_eventMapping) {
     console.log(`🔔 Event mapping loaded: ${_eventMapping.event_type} → ${_eventMapping.service_type}`);
+  }
+
+  // Load optional heatmap mapping
+  _heatmapMapping = loadHeatmapMapping();
+  if (_heatmapMapping) {
+    console.log(`🔥 Heatmap mapping loaded: ${_heatmapMapping.capability_type} (${Object.keys(_heatmapMapping.maturity_scale).join(', ')})`);
   }
 } catch (err) {
   _loadError = err instanceof Error ? err.message : String(err);
@@ -279,3 +287,18 @@ export function getEventFlows(domainId: string): EventFlow | null {
 
 // Re-export types for consumers
 export type { EventFlow, EventNode, ServiceNode, EventEdge } from '../lib/event-mapping-loader';
+
+// ─────────────────────────────────────────────────────────────
+// Heatmap API — optional, driven by heatmap-mapping.yaml
+// ─────────────────────────────────────────────────────────────
+
+/** Whether heatmap mapping is configured (heatmap-mapping.yaml exists and is valid) */
+export const heatmapMappingEnabled: boolean = _heatmapMapping !== null;
+
+/** Get the heatmap mapping config (null if not configured) */
+export function getHeatmapConfig(): HeatmapMappingConfig | null {
+  return _heatmapMapping;
+}
+
+// Re-export types for consumers
+export type { HeatmapMappingConfig } from '../lib/heatmap-mapping-loader';

--- a/catalog-ui/src/layouts/Layout.astro
+++ b/catalog-ui/src/layouts/Layout.astro
@@ -49,8 +49,8 @@ const activeDomainData = activeDomain ? domains.find(d => d.id === activeDomain)
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
         </a>
 
-        <!-- Visualiser -->
-        <a href="#" class="icon-bar-item" title="Visualiser">
+        <!-- Maps -->
+        <a href="/maps" class="icon-bar-item" title="Maps">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
         </a>
 
@@ -89,7 +89,7 @@ const activeDomainData = activeDomain ? domains.find(d => d.id === activeDomain)
 
       <!-- Nav content -->
       <nav class="sidebar-nav">
-        {!activeDomainData ? (
+        {sidebarContent === 'domains' ? (
           /* ── Top-level: Domain list ── */
           <>
             <div class="sidebar-group">

--- a/catalog-ui/src/lib/heatmap-mapping-loader.ts
+++ b/catalog-ui/src/lib/heatmap-mapping-loader.ts
@@ -1,0 +1,122 @@
+// catalog-ui/src/lib/heatmap-mapping-loader.ts
+// ═══════════════════════════════════════════════════════════════
+// Heatmap Mapping Loader
+// ═══════════════════════════════════════════════════════════════
+//
+// Reads the optional models/heatmap-mapping.yaml and resolves
+// capability heatmap configuration for domain-scoped views.
+//
+// The heatmap-mapping.yaml bridges vocabulary-agnostic registry
+// types to semantic capability-assessment roles using element
+// type KEYS and field KEYS from registry-mapping.yaml.
+// ═══════════════════════════════════════════════════════════════
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import yaml from 'js-yaml';
+
+// ─────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────
+
+export interface SizeSpec {
+  cols: number;
+  rows: number;
+}
+
+export interface HeatmapMappingConfig {
+  capability_type: string;                    // element type key for "capability" role
+  maturity_field: string;                     // field key for maturity dimension
+  lifecycle_field: string;                    // field key for lifecycle dimension
+  sourcing_field: string;                     // field key for sourcing dimension
+  size_field: string;                         // field key for treemap tile size
+  maturity_scale: Record<string, string>;     // maturity value → color
+  size_scale: Record<string, SizeSpec>;       // size value → grid span (cols, rows)
+  realization_field?: string;                 // optional relationship field key to display
+  capability_label?: string;                  // optional display override
+  maturity_label?: string;                    // optional display override
+  lifecycle_label?: string;                   // optional display override
+  sourcing_label?: string;                    // optional display override
+}
+
+// ─────────────────────────────────────────────────────────────
+// Loader
+// ─────────────────────────────────────────────────────────────
+
+const WORKSPACE_ROOT = resolve(import.meta.dirname ?? __dirname, '..', '..', '..');
+
+/**
+ * Load the heatmap-mapping.yaml config.
+ * Returns null if the file doesn't exist (feature is optional).
+ */
+export function loadHeatmapMapping(): HeatmapMappingConfig | null {
+  const configPath = join(WORKSPACE_ROOT, 'models', 'heatmap-mapping.yaml');
+  if (!existsSync(configPath)) return null;
+
+  try {
+    const raw = readFileSync(configPath, 'utf-8');
+    const parsed = yaml.load(raw) as Record<string, unknown>;
+
+    if (!parsed || typeof parsed !== 'object') return null;
+
+    // Parse maturity_scale: { Excellent: '#10b981', ... }
+    const maturityScaleRaw = parsed.maturity_scale;
+    const maturityScale: Record<string, string> = {};
+    if (maturityScaleRaw && typeof maturityScaleRaw === 'object') {
+      for (const [key, val] of Object.entries(maturityScaleRaw as Record<string, unknown>)) {
+        maturityScale[key] = String(val);
+      }
+    }
+
+    // Parse size_scale: { s: { cols: 1, rows: 1 }, ... }
+    const sizeScaleRaw = parsed.size_scale;
+    const sizeScale: Record<string, SizeSpec> = {};
+    if (sizeScaleRaw && typeof sizeScaleRaw === 'object') {
+      for (const [key, val] of Object.entries(sizeScaleRaw as Record<string, unknown>)) {
+        if (val && typeof val === 'object') {
+          const spec = val as Record<string, unknown>;
+          sizeScale[key] = {
+            cols: Number(spec.cols ?? 1),
+            rows: Number(spec.rows ?? 1),
+          };
+        }
+      }
+    }
+
+    const config: HeatmapMappingConfig = {
+      capability_type: String(parsed.capability_type ?? ''),
+      maturity_field: String(parsed.maturity_field ?? ''),
+      lifecycle_field: String(parsed.lifecycle_field ?? ''),
+      sourcing_field: String(parsed.sourcing_field ?? ''),
+      size_field: String(parsed.size_field ?? ''),
+      maturity_scale: maturityScale,
+      size_scale: sizeScale,
+      realization_field: parsed.realization_field as string | undefined,
+      capability_label: parsed.capability_label as string | undefined,
+      maturity_label: parsed.maturity_label as string | undefined,
+      lifecycle_label: parsed.lifecycle_label as string | undefined,
+      sourcing_label: parsed.sourcing_label as string | undefined,
+    };
+
+    // Validate required fields
+    if (!config.capability_type || !config.maturity_field || !config.lifecycle_field || !config.sourcing_field || !config.size_field) {
+      console.warn('⚠️  heatmap-mapping.yaml is missing required fields (capability_type, maturity_field, lifecycle_field, sourcing_field, size_field)');
+      return null;
+    }
+
+    if (Object.keys(config.maturity_scale).length === 0) {
+      console.warn('⚠️  heatmap-mapping.yaml maturity_scale is empty');
+      return null;
+    }
+
+    if (Object.keys(config.size_scale).length === 0) {
+      console.warn('⚠️  heatmap-mapping.yaml size_scale is empty');
+      return null;
+    }
+
+    return config;
+  } catch (err) {
+    console.warn(`⚠️  Failed to parse heatmap-mapping.yaml: ${err instanceof Error ? err.message : err}`);
+    return null;
+  }
+}

--- a/catalog-ui/src/pages/catalog/[id].astro
+++ b/catalog-ui/src/pages/catalog/[id].astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
-import { elements, getElementById, getDomainById, getElementsByDomain, LAYER_META, TYPE_BADGES, REL_TYPE_LABELS, getExtraFields, eventMappingEnabled, type LayerKey } from '../../data/registry';
+import { elements, getElementById, getDomainById, getElementsByDomain, LAYER_META, TYPE_BADGES, REL_TYPE_LABELS, getExtraFields, eventMappingEnabled, heatmapMappingEnabled, type LayerKey } from '../../data/registry';
+import { getDiagramsByDomain } from '../../data/diagrams-mock';
 import ElementContextGraph from '../../components/graphs/ElementContextGraph';
 import { marked } from 'marked';
 
@@ -13,6 +14,7 @@ const element = getElementById(id!)!;
 const domain = getDomainById(element.domain);
 const layer = LAYER_META[element.layer];
 const domainElements = domain ? getElementsByDomain(domain.id) : [];
+const domainDiagrams = domain ? getDiagramsByDomain(domain.id) : [];
 const extraFields = getExtraFields(element);
 
 // Badge categories derived from mapping YAML — no hardcoded type list
@@ -77,13 +79,48 @@ for (const el of domainElements) {
       </div>
       <div class="sidebar-group-items">
         <a href={domain ? `/domains/${domain.id}` : '/'} class="sidebar-item">Architecture Overview</a>
-        <a href={domain ? `/domains/${domain.id}/context-map` : '/'} class="sidebar-item">Domain Context Map</a>
         <a href={domain ? `/domains/${domain.id}/docs` : '/'} class="sidebar-item">Documentation</a>
+      </div>
+    </div>
+
+    {/* Maps section in sidebar */}
+    <div class="sidebar-group">
+      <div class="sidebar-group-header">
+        <span class="sidebar-group-icon" style="background: #6366f115; color: #6366f1;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+        </span>
+        <span class="sidebar-group-title">Maps</span>
+      </div>
+      <div class="sidebar-group-items">
+        <a href={domain ? `/domains/${domain.id}/context-map` : '/'} class="sidebar-item">Domain Context Map</a>
         {eventMappingEnabled && domain && (
           <a href={`/domains/${domain.id}/events`} class="sidebar-item">Event Map</a>
         )}
+        {heatmapMappingEnabled && (
+          <a href={domain ? `/domains/${domain.id}/heatmap` : '/'} class="sidebar-item"><span>Capability Heatmap</span></a>
+        )}
       </div>
     </div>
+
+    {/* Diagrams section in sidebar */}
+    {domainDiagrams.length > 0 && (
+      <div class="sidebar-group">
+        <div class="sidebar-group-header">
+          <span class="sidebar-group-icon" style="background: #f59e0b15; color: #f59e0b;">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.5 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+          </span>
+          <span class="sidebar-group-title">Diagrams</span>
+        </div>
+        <div class="sidebar-group-items">
+          {domainDiagrams.map(d => (
+            <a href={`/diagrams/${d.id}`} class="sidebar-item">
+              <span style="flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{d.name}</span>
+              <span class="sidebar-type-label">{d.format}</span>
+            </a>
+          ))}
+        </div>
+      </div>
+    )}
 
     {Object.entries(elementsByLayer).map(([layerKey, groups]) => {
       const l = LAYER_META[layerKey as LayerKey];

--- a/catalog-ui/src/pages/diagrams/[id].astro
+++ b/catalog-ui/src/pages/diagrams/[id].astro
@@ -5,7 +5,7 @@
 import Layout from '../../layouts/Layout.astro';
 import { DiagramViewer } from '../../components/diagrams';
 import { diagrams, getDiagramById, getDiagramsByDomain } from '../../data/diagrams-mock';
-import { domains, getElementsByDomain, LAYER_META, eventMappingEnabled, type LayerKey } from '../../data/registry';
+import { domains, getElementsByDomain, LAYER_META, eventMappingEnabled, heatmapMappingEnabled, type LayerKey } from '../../data/registry';
 
 export function getStaticPaths() {
   return diagrams.map(d => ({
@@ -59,16 +59,31 @@ const fc = formatColors[diagram.format];
         <a href={`/domains/${diagram.domain}`} class="sidebar-item">
           <span>Architecture Overview</span>
         </a>
-        <a href={`/domains/${diagram.domain}/context-map`} class="sidebar-item">
-          <span>Domain Context Map</span>
-        </a>
         <a href={`/domains/${diagram.domain}/docs`} class="sidebar-item">
           <span>Documentation</span>
+        </a>
+      </div>
+    </div>
+
+    {/* Maps section */}
+    <div class="sidebar-group">
+      <div class="sidebar-group-header">
+        <span class="sidebar-group-icon" style="background: #6366f115; color: #6366f1;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+        </span>
+        <span class="sidebar-group-title">Maps</span>
+      </div>
+      <div class="sidebar-group-items">
+        <a href={`/domains/${diagram.domain}/context-map`} class="sidebar-item">
+          <span>Domain Context Map</span>
         </a>
         {eventMappingEnabled && (
           <a href={`/domains/${diagram.domain}/events`} class="sidebar-item">
             <span>Event Map</span>
           </a>
+        )}
+        {heatmapMappingEnabled && (
+          <a href={`/domains/${diagram.domain}/heatmap`} class="sidebar-item"><span>Capability Heatmap</span></a>
         )}
       </div>
     </div>

--- a/catalog-ui/src/pages/domains/[id]/context-map.astro
+++ b/catalog-ui/src/pages/domains/[id]/context-map.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
-import { domains, getElementsByDomain, getDomainById, LAYER_META, TYPE_BADGES, eventMappingEnabled, type LayerKey } from '../../../data/registry';
+import { domains, getElementsByDomain, getDomainById, LAYER_META, TYPE_BADGES, eventMappingEnabled, heatmapMappingEnabled, type LayerKey } from '../../../data/registry';
 import { getDiagramsByDomain } from '../../../data/diagrams-mock';
 import DomainContextMap from '../../../components/graphs/DomainContextMap';
 
@@ -49,16 +49,31 @@ for (const el of domainElements) {
         <a href={`/domains/${id}`} class="sidebar-item">
           <span>Architecture Overview</span>
         </a>
-        <a href={`/domains/${id}/context-map`} class="sidebar-item active">
-          <span>Domain Context Map</span>
-        </a>
         <a href={`/domains/${id}/docs`} class="sidebar-item">
           <span>Documentation</span>
+        </a>
+      </div>
+    </div>
+
+    {/* Maps section in sidebar */}
+    <div class="sidebar-group">
+      <div class="sidebar-group-header">
+        <span class="sidebar-group-icon" style="background: #6366f115; color: #6366f1;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+        </span>
+        <span class="sidebar-group-title">Maps</span>
+      </div>
+      <div class="sidebar-group-items">
+        <a href={`/domains/${id}/context-map`} class="sidebar-item active">
+          <span>Domain Context Map</span>
         </a>
         {eventMappingEnabled && (
           <a href={`/domains/${id}/events`} class="sidebar-item">
             <span>Event Map</span>
           </a>
+        )}
+        {heatmapMappingEnabled && (
+          <a href={`/domains/${id}/heatmap`} class="sidebar-item"><span>Capability Heatmap</span></a>
         )}
       </div>
     </div>

--- a/catalog-ui/src/pages/domains/[id]/docs.astro
+++ b/catalog-ui/src/pages/domains/[id]/docs.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
-import { domains, getElementsByDomain, getDomainById, LAYER_META, TYPE_BADGES, eventMappingEnabled, type LayerKey } from '../../../data/registry';
+import { domains, getElementsByDomain, getDomainById, LAYER_META, TYPE_BADGES, eventMappingEnabled, heatmapMappingEnabled, type LayerKey } from '../../../data/registry';
 import { getDiagramsByDomain } from '../../../data/diagrams-mock';
 import { marked } from 'marked';
 
@@ -48,17 +48,32 @@ for (const el of domainElements) {
         <a href={`/domains/${id}`} class="sidebar-item">
           <span>Architecture Overview</span>
         </a>
-        <a href={`/domains/${id}/context-map`} class="sidebar-item">
-          <span>Domain Context Map</span>
-        </a>
         <a href={`/domains/${id}/docs`} class="sidebar-item active">
           <span>Documentation</span>
           {!domain.docs && <span class="sidebar-type-label" style="font-size: 9px; opacity: 0.5;">empty</span>}
+        </a>
+      </div>
+    </div>
+
+    {/* Maps section in sidebar */}
+    <div class="sidebar-group">
+      <div class="sidebar-group-header">
+        <span class="sidebar-group-icon" style="background: #6366f115; color: #6366f1;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+        </span>
+        <span class="sidebar-group-title">Maps</span>
+      </div>
+      <div class="sidebar-group-items">
+        <a href={`/domains/${id}/context-map`} class="sidebar-item">
+          <span>Domain Context Map</span>
         </a>
         {eventMappingEnabled && (
           <a href={`/domains/${id}/events`} class="sidebar-item">
             <span>Event Map</span>
           </a>
+        )}
+        {heatmapMappingEnabled && (
+          <a href={`/domains/${id}/heatmap`} class="sidebar-item"><span>Capability Heatmap</span></a>
         )}
       </div>
     </div>

--- a/catalog-ui/src/pages/domains/[id]/events.astro
+++ b/catalog-ui/src/pages/domains/[id]/events.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
-import { domains, getElementsByDomain, getDomainById, LAYER_META, TYPE_BADGES, eventMappingEnabled, getEventFlows, type LayerKey } from '../../../data/registry';
+import { domains, getElementsByDomain, getDomainById, LAYER_META, TYPE_BADGES, eventMappingEnabled, heatmapMappingEnabled, getEventFlows, type LayerKey } from '../../../data/registry';
 import { getDiagramsByDomain } from '../../../data/diagrams-mock';
 import EventFlowGraph from '../../../components/graphs/EventFlowGraph';
 
@@ -71,16 +71,31 @@ if (eventFlow) {
         <a href={`/domains/${id}`} class="sidebar-item">
           <span>Architecture Overview</span>
         </a>
-        <a href={`/domains/${id}/context-map`} class="sidebar-item">
-          <span>Domain Context Map</span>
-        </a>
         <a href={`/domains/${id}/docs`} class="sidebar-item">
           <span>Documentation</span>
+        </a>
+      </div>
+    </div>
+
+    {/* Maps section in sidebar */}
+    <div class="sidebar-group">
+      <div class="sidebar-group-header">
+        <span class="sidebar-group-icon" style="background: #6366f115; color: #6366f1;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+        </span>
+        <span class="sidebar-group-title">Maps</span>
+      </div>
+      <div class="sidebar-group-items">
+        <a href={`/domains/${id}/context-map`} class="sidebar-item">
+          <span>Domain Context Map</span>
         </a>
         {eventMappingEnabled && (
           <a href={`/domains/${id}/events`} class="sidebar-item active">
             <span>Event Map</span>
           </a>
+        )}
+        {heatmapMappingEnabled && (
+          <a href={`/domains/${id}/heatmap`} class="sidebar-item"><span>Capability Heatmap</span></a>
         )}
       </div>
     </div>

--- a/catalog-ui/src/pages/domains/[id]/heatmap.astro
+++ b/catalog-ui/src/pages/domains/[id]/heatmap.astro
@@ -1,0 +1,412 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import { domains, getElementsByDomain, getDomainById, LAYER_META, eventMappingEnabled, heatmapMappingEnabled, getHeatmapConfig, type LayerKey } from '../../../data/registry';
+import { getDiagramsByDomain } from '../../../data/diagrams-mock';
+
+export function getStaticPaths() {
+  // Only generate heatmap pages if heatmap-mapping.yaml is configured
+  if (!heatmapMappingEnabled) return [];
+  return domains.map(d => ({ params: { id: d.id } }));
+}
+
+const { id } = Astro.params;
+const domain = getDomainById(id!)!;
+const domainElements = getElementsByDomain(id!);
+const domainDiagrams = getDiagramsByDomain(id!);
+
+// Load heatmap config from heatmap-mapping.yaml
+const heatmapConfig = getHeatmapConfig()!;
+
+// Filter to capabilities for this domain using configured type key
+// Per Maps Architecture: map views CAN reference specific element types
+const capabilities = domainElements.filter(el => el.type === heatmapConfig.capability_type);
+
+// Maturity color scale (the "heat" dimension) — from mapping YAML
+const maturityColors = heatmapConfig.maturity_scale;
+
+// Size scale — from mapping YAML
+const sizeScale = heatmapConfig.size_scale;
+
+// Derive "mature" threshold from top half of maturity scale keys
+const scaleKeys = Object.keys(maturityColors);
+const matureThreshold = Math.ceil(scaleKeys.length / 2);
+const matureKeys = new Set(scaleKeys.slice(0, matureThreshold));
+
+// Luminance-based text color for treemap tiles
+function getTextColor(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.55 ? '#1a1a2e' : '#ffffff';
+}
+
+// Group elements by layer → type (for sidebar)
+type GroupedElements = Record<string, { type: string; typeLabel: string; elements: typeof domainElements }[]>;
+const elementsByLayer: GroupedElements = {};
+
+for (const el of domainElements) {
+  if (!elementsByLayer[el.layer]) elementsByLayer[el.layer] = [];
+  const existing = elementsByLayer[el.layer].find(g => g.type === el.type);
+  if (existing) {
+    existing.elements.push(el);
+  } else {
+    elementsByLayer[el.layer].push({
+      type: el.type, typeLabel: el.typeLabel,
+      elements: [el],
+    });
+  }
+}
+---
+
+<Layout title={`${domain.name} – Capability Heatmap`} activeDomain={id} sidebarContent="domain-detail">
+  <!-- Sidebar slot: domain element navigation -->
+  <Fragment slot="sidebar">
+    <div class="sidebar-group">
+      <div class="sidebar-group-header">
+        <span class="sidebar-group-icon">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="4"/><path d="M12 2v4"/><path d="M12 18v4"/><path d="M4.93 4.93l2.83 2.83"/><path d="M16.24 16.24l2.83 2.83"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="M4.93 19.07l2.83-2.83"/><path d="M16.24 7.76l2.83-2.83"/></svg>
+        </span>
+        <span class="sidebar-group-title">Overview</span>
+      </div>
+      <div class="sidebar-group-items">
+        <a href={`/domains/${id}`} class="sidebar-item">
+          <span>Architecture Overview</span>
+        </a>
+        <a href={`/domains/${id}/docs`} class="sidebar-item">
+          <span>Documentation</span>
+        </a>
+      </div>
+    </div>
+
+    {/* Maps section in sidebar */}
+    <div class="sidebar-group">
+      <div class="sidebar-group-header">
+        <span class="sidebar-group-icon" style="background: #6366f115; color: #6366f1;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+        </span>
+        <span class="sidebar-group-title">Maps</span>
+      </div>
+      <div class="sidebar-group-items">
+        <a href={`/domains/${id}/context-map`} class="sidebar-item">
+          <span>Domain Context Map</span>
+        </a>
+        {eventMappingEnabled && (
+          <a href={`/domains/${id}/events`} class="sidebar-item">
+            <span>Event Map</span>
+          </a>
+        )}
+        <a href={`/domains/${id}/heatmap`} class="sidebar-item active"><span>Capability Heatmap</span></a>
+      </div>
+    </div>
+
+    {/* Diagrams section in sidebar */}
+    {domainDiagrams.length > 0 && (
+      <div class="sidebar-group">
+        <div class="sidebar-group-header">
+          <span class="sidebar-group-icon" style="background: #f59e0b15; color: #f59e0b;">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.5 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+          </span>
+          <span class="sidebar-group-title">Diagrams</span>
+        </div>
+        <div class="sidebar-group-items">
+          {domainDiagrams.map(d => (
+            <a href={`/diagrams/${d.id}`} class="sidebar-item">
+              <span style="flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{d.name}</span>
+              <span class="sidebar-type-label">{d.format}</span>
+            </a>
+          ))}
+        </div>
+      </div>
+    )}
+
+    {Object.entries(elementsByLayer).map(([layerKey, groups]) => {
+      const layer = LAYER_META[layerKey as LayerKey];
+      return (
+        <div class="sidebar-group">
+          <div class="sidebar-group-header">
+            <span class="sidebar-group-icon" style={`background: ${layer.color}15; color: ${layer.color};`}>
+              <span style={`width: 8px; height: 8px; border-radius: 2px; background: ${layer.color};`}></span>
+            </span>
+            <span class="sidebar-group-title">{layer.name}</span>
+          </div>
+          <div class="sidebar-group-items">
+            {groups.map(group => (
+              group.elements.map(el => (
+                <a href={`/catalog/${el.id}`} class="sidebar-item">
+                  <span style="flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{el.name}</span>
+                  <span class="sidebar-type-label">{group.typeLabel}</span>
+                </a>
+              ))
+            ))}
+          </div>
+        </div>
+      );
+    })}
+  </Fragment>
+
+  <!-- Page Content -->
+  <div class="page-header" style={`border-top: 3px solid ${domain.color};`}>
+    <div class="page-header-breadcrumb">
+      <a href="/">Domains</a>
+      <span>/</span>
+      <a href={`/domains/${id}`}>{domain.name}</a>
+      <span>/</span>
+    </div>
+    <div class="page-header-title">
+      <h1>Capability Heatmap</h1>
+      <span class="badge badge-sm badge-capability">Capability Assessment</span>
+    </div>
+    <p class="page-header-summary">Business capability maturity and sourcing assessment for {domain.name}</p>
+  </div>
+
+  <div class="page-body">
+    {capabilities.length > 0 ? (
+      <>
+        {/* Stats row */}
+        <div class="stat-row">
+          <div class="stat-card">
+            <div class="stat-value" style="font-size: 24px;">{capabilities.length}</div>
+            <div class="stat-label">Capabilities</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-value" style="font-size: 24px;">{capabilities.filter(c => matureKeys.has(c.fields[heatmapConfig.maturity_field] as string)).length}</div>
+            <div class="stat-label">Mature ({Array.from(matureKeys).join('/')})</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-value" style="font-size: 24px;">{capabilities.filter(c => (c.fields[heatmapConfig.sourcing_field] as string) === 'in-house').length}</div>
+            <div class="stat-label">In-House</div>
+          </div>
+          {heatmapConfig.realization_field && (
+            <div class="stat-card">
+              <div class="stat-value" style="font-size: 24px;">{capabilities.flatMap(c => c.relationships.filter(r => r.fieldKey === heatmapConfig.realization_field)).length}</div>
+              <div class="stat-label">Realizing Components</div>
+            </div>
+          )}
+        </div>
+
+        {/* Heatmap Treemap */}
+        <div class="detail-section">
+          <div class="detail-section-title">Capability Heatmap</div>
+
+          {/* Legend */}
+          <div class="heatmap-legend">
+            {Object.entries(maturityColors).map(([label, color]) => (
+              <div class="heatmap-legend-item">
+                <span class="heatmap-legend-swatch" style={`background: ${color};`}></span>
+                <span>{label}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Treemap grid */}
+          <div class="heatmap-treemap">
+            {capabilities.map(cap => {
+              const maturity = (cap.fields[heatmapConfig.maturity_field] as string) || scaleKeys.at(-1) || 'Initial';
+              const lifecycle = cap.fields[heatmapConfig.lifecycle_field] as string;
+              const sourcing = cap.fields[heatmapConfig.sourcing_field] as string;
+              const size = (cap.fields[heatmapConfig.size_field] as string) || 'm';
+              const bgColor = maturityColors[maturity] || '#94a3b8';
+              const textColor = getTextColor(bgColor);
+              const spec = sizeScale[size] || { cols: 2, rows: 1 };
+              const realized = heatmapConfig.realization_field
+                ? cap.relationships.filter(r => r.fieldKey === heatmapConfig.realization_field)
+                : [];
+
+              return (
+                <a href={`/catalog/${cap.id}`}
+                   class="heatmap-tile"
+                   style={`grid-column: span ${spec.cols}; grid-row: span ${spec.rows}; background: ${bgColor}; color: ${textColor};`}>
+                  <div class="heatmap-tile-name">{cap.name}</div>
+                  <div class="heatmap-tile-maturity">{maturity}</div>
+                  <div class="heatmap-tile-badges">
+                    {lifecycle && <span class="heatmap-tile-badge">{lifecycle}</span>}
+                    {sourcing && <span class="heatmap-tile-badge">{sourcing}</span>}
+                  </div>
+                  {cap.owner && <div class="heatmap-tile-owner">Owner: {cap.owner}</div>}
+                  {realized.length > 0 && (
+                    <div class="heatmap-tile-realized">
+                      {realized.map(r => r.targetName).join(' · ')}
+                    </div>
+                  )}
+                </a>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Summary Table */}
+        <div class="detail-section">
+          <div class="detail-section-title">Capability Summary</div>
+          <div style="border: 1px solid rgb(var(--ec-page-border)); border-radius: 10px; overflow-x: auto;">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Capability</th>
+                  <th>Maturity</th>
+                  <th>Lifecycle</th>
+                  <th>Sourcing</th>
+                  <th>Size</th>
+                  {heatmapConfig.realization_field && <th>Realized By</th>}
+                </tr>
+              </thead>
+              <tbody>
+                {capabilities.map(cap => {
+                  const maturity = (cap.fields[heatmapConfig.maturity_field] as string) || scaleKeys.at(-1) || 'Initial';
+                  const lifecycle = cap.fields[heatmapConfig.lifecycle_field] as string;
+                  const sourcing = cap.fields[heatmapConfig.sourcing_field] as string;
+                  const size = (cap.fields[heatmapConfig.size_field] as string) || 'm';
+                  const realized = heatmapConfig.realization_field
+                    ? cap.relationships.filter(r => r.fieldKey === heatmapConfig.realization_field)
+                    : [];
+                  return (
+                    <tr>
+                      <td>
+                        <a href={`/catalog/${cap.id}`} class="table-link">{cap.name}</a>
+                        {cap.description && (
+                          <div style="font-size: 11px; color: rgb(var(--ec-page-text-muted)); margin-top: 2px; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                            {cap.description}
+                          </div>
+                        )}
+                      </td>
+                      <td><span class={`badge badge-sm badge-${maturity.toLowerCase()}`}>{maturity}</span></td>
+                      <td>
+                        {lifecycle
+                          ? <span class={`badge badge-sm badge-${lifecycle.toLowerCase()}`}>{lifecycle}</span>
+                          : <span style="color: rgb(var(--ec-page-text-muted));">&mdash;</span>
+                        }
+                      </td>
+                      <td>
+                        {sourcing
+                          ? <span class={`badge badge-sm badge-${sourcing.toLowerCase()}`}>{sourcing}</span>
+                          : <span style="color: rgb(var(--ec-page-text-muted));">&mdash;</span>
+                        }
+                      </td>
+                      <td><span style="font-size: 12px; text-transform: uppercase; font-weight: 600; letter-spacing: 0.05em; color: rgb(var(--ec-page-text-muted));">{size}</span></td>
+                      {heatmapConfig.realization_field && (
+                        <td style="font-size: 12px;">
+                          {realized.length > 0
+                            ? <span class="rel-cell-pills">{realized.map(r => <a href={`/catalog/${r.target}`} class="rel-pill rel-pill-out">{r.targetName}</a>)}</span>
+                            : <span style="color: rgb(var(--ec-page-text-muted));">&mdash;</span>
+                          }
+                        </td>
+                      )}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </>
+    ) : (
+      <div style="padding: 40px 24px; text-align: center; background: rgb(var(--ec-content-hover)); border-radius: 10px; border: 1px dashed rgb(var(--ec-page-border));">
+        <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="rgb(var(--ec-page-text-muted))" stroke-width="1" style="margin: 0 auto 12px; display: block; opacity: 0.4;">
+          <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>
+        </svg>
+        <div style="font-size: 14px; font-weight: 500; color: rgb(var(--ec-page-text-muted)); margin-bottom: 6px;">No capabilities in this domain</div>
+        <div style="font-size: 12px; color: rgb(var(--ec-page-text-muted)); opacity: 0.7;">
+          Business capabilities will appear here when capability elements are registered for this domain.
+        </div>
+      </div>
+    )}
+  </div>
+</Layout>
+
+<style>
+  /* Heatmap Legend */
+  .heatmap-legend {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 16px;
+    padding: 10px 16px;
+    background: rgb(var(--ec-content-hover));
+    border-radius: 8px;
+    border: 1px solid rgb(var(--ec-page-border));
+  }
+
+  .heatmap-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: rgb(var(--ec-page-text-muted));
+    font-weight: 500;
+  }
+
+  .heatmap-legend-swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  /* Heatmap Treemap Grid */
+  .heatmap-treemap {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-auto-flow: dense;
+    gap: 8px;
+  }
+
+  .heatmap-tile {
+    border-radius: 10px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-height: 100px;
+    text-decoration: none;
+    transition: transform 0.15s, box-shadow 0.15s;
+    overflow: hidden;
+  }
+
+  .heatmap-tile:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .heatmap-tile-name {
+    font-size: 15px;
+    font-weight: 700;
+    line-height: 1.3;
+  }
+
+  .heatmap-tile-maturity {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    opacity: 0.85;
+  }
+
+  .heatmap-tile-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 2px;
+  }
+
+  .heatmap-tile-badge {
+    font-size: 10px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.2);
+    font-weight: 500;
+    line-height: 1.4;
+  }
+
+  .heatmap-tile-owner {
+    font-size: 11px;
+    opacity: 0.7;
+    margin-top: auto;
+  }
+
+  .heatmap-tile-realized {
+    font-size: 11px;
+    opacity: 0.75;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    padding-top: 6px;
+    line-height: 1.4;
+  }
+</style>

--- a/catalog-ui/src/pages/domains/[id]/index.astro
+++ b/catalog-ui/src/pages/domains/[id]/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
-import { domains, getElementsByDomain, getDomainById, LAYER_META, TYPE_BADGES, getRelFieldLabel, eventMappingEnabled, type LayerKey } from '../../../data/registry';
+import { domains, getElementsByDomain, getDomainById, LAYER_META, TYPE_BADGES, getRelFieldLabel, eventMappingEnabled, heatmapMappingEnabled, type LayerKey } from '../../../data/registry';
 import { getDiagramsByDomain } from '../../../data/diagrams-mock';
 
 
@@ -139,17 +139,32 @@ for (const [layerKey, groups] of Object.entries(elementsByLayer)) {
         <a href={`/domains/${id}`} class="sidebar-item active">
           <span>Architecture Overview</span>
         </a>
-        <a href={`/domains/${id}/context-map`} class="sidebar-item">
-          <span>Domain Context Map</span>
-        </a>
         <a href={`/domains/${id}/docs`} class="sidebar-item">
           <span>Documentation</span>
           {!domain.docs && <span class="sidebar-type-label" style="font-size: 9px; opacity: 0.5;">empty</span>}
+        </a>
+      </div>
+    </div>
+
+    {/* Maps section in sidebar */}
+    <div class="sidebar-group">
+      <div class="sidebar-group-header">
+        <span class="sidebar-group-icon" style="background: #6366f115; color: #6366f1;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+        </span>
+        <span class="sidebar-group-title">Maps</span>
+      </div>
+      <div class="sidebar-group-items">
+        <a href={`/domains/${id}/context-map`} class="sidebar-item">
+          <span>Domain Context Map</span>
         </a>
         {eventMappingEnabled && (
           <a href={`/domains/${id}/events`} class="sidebar-item">
             <span>Event Map</span>
           </a>
+        )}
+        {heatmapMappingEnabled && (
+          <a href={`/domains/${id}/heatmap`} class="sidebar-item"><span>Capability Heatmap</span></a>
         )}
       </div>
     </div>

--- a/catalog-ui/src/pages/maps/index.astro
+++ b/catalog-ui/src/pages/maps/index.astro
@@ -1,0 +1,32 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { domains, eventMappingEnabled, heatmapMappingEnabled } from '../../data/registry';
+---
+
+<Layout title="Maps">
+  <div class="page-header">
+    <div class="page-header-title">
+      <h1>Maps</h1>
+    </div>
+    <p class="page-header-summary">Analytical views across architecture domains</p>
+  </div>
+
+  <div class="page-body">
+    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px;">
+      {domains.map(d => (
+        <div class="card" style={`padding: 20px; border-top: 3px solid ${d.color};`}>
+          <h3 style="font-size: 15px; font-weight: 600; margin: 0 0 12px; color: rgb(var(--ec-page-text));">{d.name}</h3>
+          <div style="display: flex; flex-direction: column; gap: 8px;">
+            <a href={`/domains/${d.id}/context-map`} style="font-size: 13px; color: rgb(59, 130, 246); text-decoration: none;">Domain Context Map</a>
+            {eventMappingEnabled && (
+              <a href={`/domains/${d.id}/events`} style="font-size: 13px; color: rgb(59, 130, 246); text-decoration: none;">Event Map</a>
+            )}
+            {heatmapMappingEnabled && (
+              <a href={`/domains/${d.id}/heatmap`} style="font-size: 13px; color: rgb(59, 130, 246); text-decoration: none;">Capability Heatmap</a>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+</Layout>

--- a/catalog-ui/src/styles/global.css
+++ b/catalog-ui/src/styles/global.css
@@ -488,6 +488,7 @@ button { font-family: inherit; cursor: pointer; }
 
 /* Type badges */
 .badge-domain { background: rgb(var(--ec-badge-domain-bg)); color: rgb(var(--ec-badge-domain-text)); border-color: transparent; }
+.badge-capability { background: rgb(236 253 245); color: rgb(6 95 70); border-color: transparent; }
 .badge-component { background: rgb(243 232 255); color: rgb(126 34 206); border-color: transparent; }
 .badge-system { background: rgb(219 234 254); color: rgb(30 64 175); border-color: transparent; }
 .badge-data { background: rgb(254 243 199); color: rgb(180 83 9); border-color: transparent; }
@@ -497,6 +498,7 @@ button { font-family: inherit; cursor: pointer; }
 
 /* Status badges */
 .badge-active { background: rgb(220 252 231); color: rgb(22 101 52); border-color: transparent; }
+.badge-new { background: rgb(224 242 254); color: rgb(7 89 133); border-color: transparent; }
 .badge-planned { background: rgb(224 242 254); color: rgb(7 89 133); border-color: transparent; }
 .badge-deprecated { background: rgb(254 226 226); color: rgb(153 27 27); border-color: transparent; }
 .badge-draft { background: rgb(var(--ec-badge-default-bg)); color: rgb(var(--ec-badge-default-text)); border-color: transparent; }

--- a/models/heatmap-mapping.yaml
+++ b/models/heatmap-mapping.yaml
@@ -1,0 +1,37 @@
+# Capability Heatmap View Mapping
+# Maps registry element types to semantic heatmap roles.
+# This file is OPTIONAL — if absent, no Capability Heatmap tab appears.
+#
+# Values are element type KEYS and field KEYS from registry-mapping.yaml.
+
+capability_type: business_capability
+
+# Heatmap dimensions — field keys from the capability's frontmatter
+maturity_field: maturity
+lifecycle_field: lifecycle
+sourcing_field: sourcing
+size_field: size
+
+# Maturity color scale (the "heat" — ordered best → worst)
+maturity_scale:
+  Excellent: '#10b981'
+  Good: '#3b82f6'
+  Developing: '#f59e0b'
+  Initial: '#94a3b8'
+
+# Treemap tile sizes — maps size field values to CSS grid spans
+size_scale:
+  s:   { cols: 1, rows: 1 }
+  m:   { cols: 2, rows: 1 }
+  l:   { cols: 2, rows: 2 }
+  xl:  { cols: 3, rows: 2 }
+  xxl: { cols: 3, rows: 3 }
+
+# Optional: which relationship field to display on tiles (omit to hide)
+realization_field: realized_by_components
+
+# Optional display label overrides (defaults to field labels from registry-mapping.yaml):
+# capability_label: Business Capability
+# maturity_label: Maturity
+# lifecycle_label: Lifecycle
+# sourcing_label: Sourcing

--- a/models/registry-mapping.yaml
+++ b/models/registry-mapping.yaml
@@ -326,6 +326,22 @@ elements:
         type: string
         required: false
         label: Status
+      maturity:
+        type: string
+        required: false
+        label: Maturity
+      lifecycle:
+        type: string
+        required: false
+        label: Lifecycle
+      sourcing:
+        type: string
+        required: false
+        label: Sourcing
+      size:
+        type: string
+        required: false
+        label: Size
     relationships:
       realized_by_components:
         target: component

--- a/registry-v2/2-organization/capabilities/_template.md
+++ b/registry-v2/2-organization/capabilities/_template.md
@@ -11,6 +11,10 @@ description: <Brief description>
 owner: <owning-team>
 domain:
 status: draft | active | deprecated
+maturity: Initial | Developing | Good | Excellent
+lifecycle: new | active | retired
+sourcing: in-house | vendor | hybrid
+size: s | m | l | xl | xxl
 registered: false
 
 # ── Relationships (from draw.io arrows) ──────────────────────

--- a/registry-v2/2-organization/capabilities/account-administration.md
+++ b/registry-v2/2-organization/capabilities/account-administration.md
@@ -4,6 +4,10 @@ name: Account Administration
 description: The ability to manage tenant accounts, user provisioning, role assignments, and access control policies across the platform.
 owner: Platform Team
 status: active
+maturity: Good
+lifecycle: active
+sourcing: in-house
+size: m
 domain: Customer Management
 
 composes_process_modules: []

--- a/registry-v2/2-organization/capabilities/business-intelligence.md
+++ b/registry-v2/2-organization/capabilities/business-intelligence.md
@@ -4,6 +4,10 @@ name: Business Intelligence
 description: The ability to collect, process, and present analytics on customer engagement, usage patterns, and platform performance.
 owner: Analytics Team
 status: active
+maturity: Developing
+lifecycle: new
+sourcing: hybrid
+size: s
 domain: Analytics and Insights
 registered: false
 

--- a/registry-v2/2-organization/capabilities/contact-management.md
+++ b/registry-v2/2-organization/capabilities/contact-management.md
@@ -4,6 +4,10 @@ name: Contact Management
 description: The ability to capture, organize, and maintain customer contact information and interaction history across all touchpoints.
 owner: Platform Team
 status: active
+maturity: Developing
+lifecycle: active
+sourcing: hybrid
+size: m
 domain: Customer Management
 
 composes_process_modules: []

--- a/registry-v2/2-organization/capabilities/customer-management.md
+++ b/registry-v2/2-organization/capabilities/customer-management.md
@@ -4,6 +4,10 @@ name: Customer Management
 description: The ability to manage the full lifecycle of B2B customer relationships including acquisition, onboarding, retention, and offboarding.
 owner: Platform Team
 status: active
+maturity: Excellent
+lifecycle: active
+sourcing: in-house
+size: xl
 domain: Customer Management
 registered: false
 

--- a/registry-v2/2-organization/capabilities/subscription-management.md
+++ b/registry-v2/2-organization/capabilities/subscription-management.md
@@ -4,6 +4,10 @@ name: Subscription Management
 description: The ability to manage subscription plans, billing cycles, payment collection, and revenue recognition for B2B SaaS customers.
 owner: Billing Team
 status: active
+maturity: Good
+lifecycle: active
+sourcing: vendor
+size: l
 domain: Billing and Payments
 registered: false
 


### PR DESCRIPTION
- Add Maps sidebar section (Context Map, Event Map, Capability Heatmap) across all domain pages, catalog detail, and diagram pages
- Create domain-scoped heatmap at /domains/[id]/heatmap with treemap grid layout: colored tiles sized by capability importance, background color driven by maturity scale (the "heat")
- Add heatmap-mapping.yaml config file defining capability_type, field keys (maturity, lifecycle, sourcing, size), maturity color scale, size grid spans, and optional realization_field
- Add heatmap-mapping-loader.ts following event-mapping-loader pattern
- Wire heatmapMappingEnabled flag + getHeatmapConfig() into registry.ts
- Conditionally show/hide heatmap sidebar links via heatmapMappingEnabled
- Add size field to business_capability in registry-mapping.yaml
- Update all 5 capability .md files with maturity, lifecycle, sourcing, and size assessment values
- Add badge-capability CSS class to global.css
- Create /maps landing page with domain links
- Update Layout.astro icon bar to link to /maps