### PR TITLE
fix: read hook input from stdin instead of env var

### DIFF
--- a/.claude/hooks/check-test-exists.sh
+++ b/.claude/hooks/check-test-exists.sh
@@ -2,7 +2,8 @@
 # PostToolUse hook — warns if a catalog-ui component lacks a test file
 # Non-blocking (exit 0) — just a reminder, not a gate
 
-FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.file_path // empty' 2>/dev/null)
+INPUT=$(cat /dev/stdin 2>/dev/null)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 
 # Only check catalog-ui source files (not test files themselves)
 if [[ "$FILE_PATH" == *"catalog-ui/src/"* ]] && \

--- a/.claude/hooks/pre-commit-validate.sh
+++ b/.claude/hooks/pre-commit-validate.sh
@@ -2,7 +2,8 @@
 # PreToolUse hook — runs model validation before git commits only
 # Matches on all Bash calls, but only acts on git commit commands
 
-COMMAND=$(echo "$TOOL_INPUT" | jq -r '.command // empty' 2>/dev/null)
+INPUT=$(cat /dev/stdin 2>/dev/null)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 # Only run for git commit commands
 if [[ "$COMMAND" == *"git commit"* ]]; then


### PR DESCRIPTION
Claude Code passes tool input to hooks via stdin as JSON, not through a TOOL_INPUT environment variable. Fix both hook scripts to read from /dev/stdin and parse the nested tool_input structure correctly.