### PR TITLE
feat: deploy live demo site with Firebase Hosting

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "ea-toolkit-demo-ac513"
+  }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'catalog-ui/**'
+      - 'registry-v2/**'
+      - 'models/**'
+      - 'views/**'
+      - 'firebase.json'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: catalog-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: catalog-ui
+
+      - name: Build
+        run: npm run build
+        working-directory: catalog-ui
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          channelId: live
+          projectId: ea-toolkit-demo-ac513

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ _reference/
 dist/
 dashboard.html
 tests/tmp/
+firebase-sa-key.json
+firebase-debug.log
+.firebase/

--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
   <img src="https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black" alt="React 18" />
   <img src="https://img.shields.io/badge/License-MIT-green?logo=opensourceinitiative&logoColor=white" alt="MIT" />
   <img src="https://img.shields.io/badge/Schema_Driven-YAML-blue" alt="Schema Driven" />
+  <a href="https://architecture-catalog.web.app"><img src="https://img.shields.io/badge/Live_Demo-architecture--catalog.web.app-black?logo=firebase&logoColor=white" alt="Live Demo" /></a>
 </p>
 
 # Architecture Catalog
 
 **A schema-driven, white-label architecture catalog that turns Markdown files into a beautiful, interactive static site.**
+
+> **[Live Demo](https://architecture-catalog.web.app)** — explore a sample catalog with 3 domains and 100+ elements.
 
 Model your enterprise architecture using plain Markdown files with YAML frontmatter, define your schema in a single YAML mapping, and get a fully navigable catalog — dashboards, domain maps, element details, context graphs, and health scores — with zero custom code.
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,13 @@
+{
+  "hosting": {
+    "site": "architecture-catalog",
+    "public": "catalog-ui/dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "cleanUrls": true,
+    "trailingSlash": false
+  }
+}


### PR DESCRIPTION
## Summary
- Add Firebase Hosting config (`firebase.json`, `.firebaserc`) targeting `architecture-catalog.web.app`
- Add GitHub Action for auto-deploy on push to `main` (catalog-ui, registry, or model changes)
- Add live demo badge and link to README
- Add Firebase artifacts to `.gitignore`

## Setup Required
After merging, add the `FIREBASE_SERVICE_ACCOUNT` GitHub secret for CI/CD to work. See issue #45 for details.

## Test plan
- [ ] Verify https://architecture-catalog.web.app loads correctly
- [ ] Verify GitHub Action triggers on push to main (after secret is configured)
- [ ] Verify README badge renders and links to demo

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)