### PR TITLE
docs: documentation site with feature pages and multi-site deploy

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,18 @@
 {
   "projects": {
     "default": "ea-toolkit-demo-ac513"
-  }
+  },
+  "targets": {
+    "ea-toolkit-demo-ac513": {
+      "hosting": {
+        "catalog": [
+          "architecture-catalog"
+        ],
+        "docs": [
+          "docs-architecture-catalog"
+        ]
+      }
+    }
+  },
+  "etags": {}
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'catalog-ui/**'
+      - 'docs-site/**'
       - 'registry-v2/**'
       - 'models/**'
       - 'views/**'
@@ -22,13 +23,17 @@ jobs:
           cache: 'npm'
           cache-dependency-path: catalog-ui/package-lock.json
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Build catalog
         working-directory: catalog-ui
+        run: |
+          npm ci
+          npm run build
 
-      - name: Build
-        run: npm run build
-        working-directory: catalog-ui
+      - name: Build docs
+        working-directory: docs-site
+        run: |
+          npm ci
+          npm run build
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/catalog-ui/src/layouts/Layout.astro
+++ b/catalog-ui/src/layouts/Layout.astro
@@ -68,6 +68,10 @@ const activeDomainData = activeDomain ? domains.find(d => d.id === activeDomain)
 
       <!-- Bottom actions -->
       <div style="margin-top: auto; display: flex; flex-direction: column; align-items: center; gap: 4px; margin-bottom: 8px;">
+        <!-- Docs -->
+        <a href="https://docs-architecture-catalog.web.app" target="_blank" rel="noopener noreferrer" class="icon-bar-item" title="Documentation" aria-label="Documentation">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+        </a>
         <!-- GitHub -->
         <a href="https://github.com/ea-toolkit/architecture-catalog" target="_blank" rel="noopener noreferrer" class="icon-bar-item" title="View on GitHub" aria-label="View on GitHub">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -17,6 +17,16 @@ export default defineConfig({
 					],
 				},
 				{
+					label: 'Features',
+					items: [
+						{ label: 'Dashboard', slug: 'features/dashboard' },
+						{ label: 'Domain Overview', slug: 'features/domain-overview' },
+						{ label: 'Context Map', slug: 'features/context-map' },
+						{ label: 'Event Flow Map', slug: 'features/event-flow' },
+						{ label: 'Diagrams', slug: 'features/diagrams' },
+					],
+				},
+				{
 					label: 'Modeling Your Architecture',
 					items: [
 						{ label: 'Registry Mapping', slug: 'modeling/registry-mapping' },

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -6,7 +6,17 @@ export default defineConfig({
 	integrations: [
 		starlight({
 			title: 'Architecture Catalog',
-			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/ea-toolkit/architecture-catalog' }],
+			social: [
+				{ icon: 'github', label: 'GitHub', href: 'https://github.com/ea-toolkit/architecture-catalog' },
+			],
+			customCss: ['./src/styles/custom.css'],
+			head: [
+				// Default to dark mode (same as catalog-ui)
+				{
+					tag: 'script',
+					content: `if(!localStorage.getItem('starlight-theme')){document.documentElement.setAttribute('data-theme','dark')}`,
+				},
+			],
 			sidebar: [
 				{
 					label: 'Getting Started',

--- a/docs-site/src/content/docs/configuration/branding.md
+++ b/docs-site/src/content/docs/configuration/branding.md
@@ -5,14 +5,18 @@ description: Customize the catalog's appearance for your organization.
 
 ## Basic branding
 
-Change three lines in `registry-mapping.yaml`:
+Update the `site:` section in `registry-mapping.yaml`:
 
 ```yaml
 site:
-  name: Acme Architecture Catalog     # appears in header + page titles
-  description: Acme Corp engineering   # appears on dashboard
+  name: Architecture Catalog           # catalog name (subtitle on homepage)
+  company: Acme Corp                   # company name (main heading on homepage)
+  description: Acme Corp engineering   # appears on dashboard subtitle
   logo_text: A                         # single character in sidebar logo
+  # logo_image: /logo.svg             # optional: path to image in catalog-ui/public/
 ```
+
+When `company` is set, the homepage shows the company name as the main `h1` heading with the catalog `name` as smaller subtext below it. If `company` is omitted, the `name` is used as the main heading instead.
 
 ## Domain colors
 

--- a/docs-site/src/content/docs/configuration/mapping-reference.md
+++ b/docs-site/src/content/docs/configuration/mapping-reference.md
@@ -28,16 +28,20 @@ elements: { ... }
 
 ```yaml
 site:
-  name: Architecture Catalog       # Page title, header text
+  name: Architecture Catalog       # Catalog name (subtitle when company is set)
+  company: Nova CRM                # Company name (main homepage heading)
   description: Enterprise registry  # Dashboard subtitle
-  logo_text: A                     # Single char in sidebar logo
+  logo_text: N                     # Single char in sidebar logo
+  # logo_image: /logo.svg         # Optional: path to logo image
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | yes | Shown in page titles, sidebar, breadcrumbs |
+| `name` | string | yes | Catalog name. Shown in page titles and sidebar. Used as homepage heading when `company` is not set. |
+| `company` | string | no | Company/organization name. When set, shown as the main homepage heading with `name` as subtitle. |
 | `description` | string | yes | Shown on the dashboard landing page |
 | `logo_text` | string | yes | Single character in the sidebar icon bar |
+| `logo_image` | string | no | Path to a logo image in `catalog-ui/public/`. Overrides `logo_text` when set. |
 
 ## `layers` -- Architecture Layers
 

--- a/docs-site/src/content/docs/features/context-map.md
+++ b/docs-site/src/content/docs/features/context-map.md
@@ -1,0 +1,64 @@
+---
+title: Context Map
+description: Interactive domain dependency graphs with search, filter, and focus mode.
+---
+
+The domain context map is an interactive graph showing all elements in a domain and their relationships. It's powered by [React Flow](https://reactflow.dev) with automatic [dagre](https://github.com/dagrejs/dagre) layout.
+
+<!-- VIDEO: #3 Domain Context Map — open context map, zoom/pan, search, toggle legend, focus mode (45s) -->
+
+## Layout
+
+Elements are arranged left-to-right based on their `graph_rank` from the mapping YAML:
+
+```
+rank 0          rank 1           rank 2           rank 3
+Domain    ->    Components  ->   Systems     ->   Events
+(anchor)        Capabilities     Subsystems       Data
+```
+
+The rank determines the column position. Elements with the same rank are stacked vertically.
+
+## Controls
+
+### Toolbar (top-right)
+
+| Control | Description |
+|---------|-------------|
+| **Search** | Type to dim non-matching nodes (matching nodes stay fully visible) |
+| **Status filter** | Toggle between All, Active, Draft, Deprecated |
+| **PNG export** | Download the current graph view as a PNG image |
+
+### Legend (bottom-right)
+
+Click any element type in the legend to **hide/show** that type in the graph. This is useful for focusing on specific layers (e.g., hide all data concepts to see only the system landscape).
+
+The legend also shows relationship types with their line styles (solid, dashed, etc.).
+
+### Zoom and pan
+
+- **Scroll** to zoom in/out
+- **Click and drag** the background to pan
+- **Zoom controls** (top-left) for step-by-step zoom, fit-to-view, and lock
+
+## Focus mode
+
+Double-click any node to enter **focus mode** — a full-screen modal showing only that element and its immediate neighbors (1 hop). Click any connected node to navigate to it, building an exploration path through the graph.
+
+Press **Escape** or click the X to exit focus mode.
+
+## Node design
+
+Each node shows:
+
+- **Header** — colored background with element type icon and name
+- **Type label** — uppercase text identifying the element type
+- **Status badge** — active/draft/deprecated
+- **Sourcing badge** — build/buy/inherit (if set)
+- **Doc link** — click to navigate to the element's detail page
+
+Nodes are styled based on their layer color from the mapping YAML. Unknown element types fall back to schema-derived colors automatically.
+
+## Edge labels
+
+Relationship edges show their type label (e.g., "composes", "realizes", "serves"). Edge styles are configured in `meta-model.config.ts` and support solid, dashed, and dotted lines.

--- a/docs-site/src/content/docs/features/dashboard.md
+++ b/docs-site/src/content/docs/features/dashboard.md
@@ -1,0 +1,54 @@
+---
+title: Dashboard
+description: The homepage dashboard with domain cards, stats, and quick navigation.
+---
+
+The dashboard is the landing page of your architecture catalog. It provides a high-level overview of your entire architecture model.
+
+<!-- VIDEO: #1 Homepage overview — open the app, dark mode, hover domain cards, scroll stats (30s) -->
+
+## What you see
+
+### Stats bar
+
+Four metric cards at the top:
+
+| Metric | Description |
+|--------|-------------|
+| **Total Entities** | Count of all registered architecture elements |
+| **Domains** | Number of auto-discovered domains |
+| **Diagrams** | Count of diagrams (PlantUML, BPMN, draw.io) |
+| **Pages** | Total generated static pages |
+
+### Domain cards
+
+Each domain gets a card showing:
+
+- **Domain name** with a color-coded left border
+- **Element count** per type (revealed on hover)
+- **Quick links** to the domain overview, context map, event flow, and heatmap
+
+Domain colors are auto-assigned from the `domain_color_palette` in your mapping YAML. Domains are sorted by element count (largest first).
+
+### Layer distribution
+
+Below the domain cards, a summary shows how elements are distributed across your architecture layers (Business, Organization, Application, Technology — or whatever layers you define).
+
+## Branding
+
+The dashboard header shows your company name and catalog name, configured in `registry-mapping.yaml`:
+
+```yaml
+site:
+  company: Nova CRM              # main heading
+  name: Architecture Catalog     # subtitle
+  logo_text: N                   # sidebar icon
+```
+
+See [Site Branding](/configuration/branding/) for the full reference.
+
+## Dark mode
+
+The catalog defaults to dark mode with a toggle button in the sidebar icon bar. Theme preference is saved to localStorage and persists across sessions. The toggle also respects the system's `prefers-color-scheme` setting on first visit.
+
+<!-- VIDEO: #6 Dark/Light toggle — toggle theme back and forth on a context map page (15s) -->

--- a/docs-site/src/content/docs/features/diagrams.md
+++ b/docs-site/src/content/docs/features/diagrams.md
@@ -1,0 +1,57 @@
+---
+title: Diagrams
+description: View PlantUML, BPMN, and draw.io diagrams inline in the catalog.
+---
+
+The catalog includes a diagram viewer that renders PlantUML, BPMN, and draw.io diagrams directly in the browser. Diagrams are organized by domain and displayed on the `/diagrams` page.
+
+<!-- VIDEO: #5 Diagrams — open diagrams page, view PlantUML, zoom, view source, switch to BPMN (30s) -->
+
+## Supported formats
+
+| Format | Renderer | Source |
+|--------|----------|--------|
+| **PlantUML** | SVG via public PlantUML server | `.puml` source in data file |
+| **BPMN** | [bpmn-js](https://bpmn.io/toolkit/bpmn-js/) | `.bpmn` XML in data file |
+| **draw.io** | Native XML renderer | `.drawio` XML in data file |
+
+## Viewer controls
+
+All diagram viewers share a consistent toolbar:
+
+| Control | Description |
+|---------|-------------|
+| **Zoom in/out** | Step-by-step zoom buttons |
+| **Fit / Reset** | Fit diagram to viewport or reset zoom level |
+| **Zoom percentage** | Shows current zoom level |
+| **Format badge** | Shows the diagram type (PlantUML, BPMN, draw.io) |
+
+### PlantUML extras
+
+- **View Source** button toggles the raw PlantUML source code below the diagram
+- **Zoom + pan** — hold Ctrl/Cmd + scroll to zoom, click-drag to pan when zoomed in
+
+### BPMN extras
+
+- Full interactive BPMN viewer with process flow visualization
+- Supports all standard BPMN 2.0 elements
+
+## Adding diagrams
+
+Diagrams are defined in `catalog-ui/src/data/diagrams-mock.ts`. Each diagram entry specifies:
+
+```typescript
+{
+  id: 'my-diagram',
+  name: 'System Architecture',
+  domain: 'customer-management',
+  format: 'plantuml',
+  source: `@startuml
+    ...
+  @enduml`,
+}
+```
+
+## Dark mode behavior
+
+Diagram canvases maintain a light background regardless of the theme setting. This ensures that diagram elements (arrows, text, shapes) rendered by external libraries (PlantUML server, bpmn-js) remain visible, since these renderers produce light-mode output natively.

--- a/docs-site/src/content/docs/features/domain-overview.md
+++ b/docs-site/src/content/docs/features/domain-overview.md
@@ -1,0 +1,42 @@
+---
+title: Domain Overview
+description: Drill into a domain to see all its elements, grouped by type.
+---
+
+Each domain has a dedicated overview page at `/domains/<domain-slug>/`. It shows all elements belonging to that domain, grouped by their element type.
+
+<!-- VIDEO: #2 Domain deep-dive — click a domain, show element list, click into element detail, show relationships (45s) -->
+
+## How to get there
+
+From the dashboard, click any domain card. Or use the sidebar — every domain appears as a navigation group with its element types listed underneath.
+
+## What you see
+
+### Element list
+
+Elements are grouped by type (Components, Software Systems, API Endpoints, Data Concepts, etc.) with counts per group. Each element card shows:
+
+- **Name** and **description**
+- **Status** badge (active, draft, deprecated)
+- **Sourcing** badge (build, buy, inherit)
+- **Link** to the element detail page
+
+### Element detail page
+
+Click any element to see its full detail page at `/catalog/<composite-id>/`. This shows:
+
+- All frontmatter fields rendered as a metadata table
+- **Outgoing relationships** — elements this one connects to
+- **Incoming relationships** — elements that connect to this one
+- **Markdown body** — free-form documentation, ADRs, runbooks
+
+### Navigation links
+
+The domain overview links to:
+
+| View | Route | Description |
+|------|-------|-------------|
+| Context Map | `/domains/<id>/context-map` | Interactive dependency graph |
+| Event Flow | `/domains/<id>/event-flow` | Event publish/consume visualization |
+| Heatmap | `/domains/<id>/heatmap` | Capability coverage matrix |

--- a/docs-site/src/content/docs/features/event-flow.md
+++ b/docs-site/src/content/docs/features/event-flow.md
@@ -1,0 +1,76 @@
+---
+title: Event Flow Map
+description: Visualize event publish/consume flows across your domain.
+---
+
+The event flow map shows how domain events flow between services — who publishes, who consumes, and the events in between.
+
+<!-- VIDEO: #4 Event Flow Map — open event flow, show animated edges, hover nodes, export PNG (30s) -->
+
+## How it works
+
+The event flow map is driven by `models/event-mapping.yaml`, which bridges registry types to semantic event-flow roles:
+
+```yaml
+service_type: software_subsystem     # what acts as a "service"
+event_type: domain_event             # what acts as an "event"
+publishes_field: published_by_api_endpoints
+consumes_field: consumed_by_api_endpoints
+```
+
+The loader follows these paths at build time:
+1. Find all domain events in the domain
+2. Follow `published_by_api_endpoints` to discover publishers
+3. Follow `consumed_by_api_endpoints` to discover consumers
+4. Auto-traverse intermediate hops (event -> API endpoint -> subsystem) via BFS
+
+## Layout
+
+The graph is arranged left-to-right in three columns:
+
+```
+Publishers  ->  Events  ->  Consumers
+(services)      (domain      (services)
+                 events)
+```
+
+Cross-domain services (consuming events from another domain) are visually marked.
+
+## Visual features
+
+| Feature | Description |
+|---------|-------------|
+| **Animated edges** | Flowing dots along publish/consume edges show data flow direction |
+| **Color coding** | Blue edges for "publishes", green edges for "consumes" |
+| **Edge labels** | Each edge shows "PUBLISHES" or "CONSUMES" in a styled badge |
+| **Cross-domain flag** | Services from other domains get a special indicator |
+| **PNG export** | Download the graph as an image |
+
+## Legend
+
+The bottom-right legend shows:
+- Publish and consume edge styles
+- Event node appearance
+- Service node appearance
+
+## Adding events
+
+To populate the event flow map, create domain event Markdown files with publish/consume connections:
+
+```yaml
+---
+type: domain-event
+name: Order Placed
+domain: Order Management
+status: active
+event_format: CloudEvents/JSON
+
+published_by_api_endpoints:
+  - order-create-endpoint
+consumed_by_api_endpoints:
+  - billing-invoice-trigger
+  - analytics-event-ingest
+---
+```
+
+The more connections your events have, the richer the event flow visualization becomes. Cross-domain consumers make the graph particularly interesting.

--- a/docs-site/src/content/docs/getting-started/installation.md
+++ b/docs-site/src/content/docs/getting-started/installation.md
@@ -32,9 +32,10 @@ npm run build
 You should see output like:
 
 ```
-Registry loaded: 34 elements, 69 edges
-  Healthy: 34  |  Connected: 34  |  Orphans: 0
+Registry loaded: 182 elements, 340 edges
+  Healthy: 182  |  Connected: 182  |  Orphans: 0
   Broken refs: 0
+286 page(s) built
 ```
 
 ## Start the dev server
@@ -43,7 +44,9 @@ Registry loaded: 34 elements, 69 edges
 npm run dev
 ```
 
-Open [http://localhost:4321](http://localhost:4321). You should see the dashboard with the Customer Management, Billing & Payments, and Analytics & Insights sample domains.
+Open [http://localhost:4321](http://localhost:4321). You should see the dashboard with 6 sample domains including Customer Management, Billing & Payments, Analytics & Insights, Integration & Connectivity, Security & Compliance, and Platform Operations.
+
+<!-- VIDEO: #1 Homepage overview — open the app, dark mode, hover domain cards, scroll stats (30s) -->
 
 ## Brand it for your organization
 
@@ -51,12 +54,13 @@ Open `models/registry-mapping.yaml` and update the `site:` section:
 
 ```yaml
 site:
-  name: Acme Architecture Catalog
-  description: Acme Corp enterprise architecture registry
-  logo_text: A
+  name: Architecture Catalog       # subtitle / catalog name
+  company: Acme Corp               # main heading on homepage
+  description: Enterprise architecture registry
+  logo_text: A                     # single character in sidebar logo
 ```
 
-Restart the dev server and your branding is applied everywhere.
+When `company` is set, the homepage shows it as the main title with the catalog `name` as subtitle. Restart the dev server and your branding is applied everywhere.
 
 ## Next steps
 

--- a/docs-site/src/content/docs/getting-started/introduction.md
+++ b/docs-site/src/content/docs/getting-started/introduction.md
@@ -41,11 +41,17 @@ The catalog works with any architecture vocabulary: ArchiMate, TOGAF, C4, or you
 
 ## What you get
 
-- **Dashboard** with model-wide statistics and domain health scores
-- **Domain overview** pages with elements grouped by type
+- **[Dashboard](/features/dashboard/)** with domain cards, model-wide statistics, and dark/light theme
+- **[Domain overview](/features/domain-overview/)** pages with elements grouped by type
 - **Element detail** pages with metadata, relationships, and rich Markdown documentation
-- **Interactive context graphs** with search, filter, and PNG export
+- **[Context maps](/features/context-map/)** — interactive dependency graphs with search, filter, focus mode, and PNG export
+- **[Event flow maps](/features/event-flow/)** — animated publish/consume diagrams showing how events flow between services
+- **[Diagrams](/features/diagrams/)** — PlantUML, BPMN, and draw.io rendered inline
 - **Discover page** for searching and filtering across the entire catalog
+
+:::tip[See it live]
+Check out the demo at [architecture-catalog.web.app](https://architecture-catalog.web.app) — 6 domains, 180+ entities, fully interactive.
+:::
 
 ## Next steps
 

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -2,54 +2,71 @@
 title: Architecture Catalog
 description: A schema-driven, white-label architecture catalog that turns Markdown files into a beautiful, interactive static site.
 template: splash
+banner:
+  content: |
+    <a href="https://architecture-catalog.web.app" target="_blank">See the live demo →</a>
 hero:
-  tagline: Model your enterprise architecture using plain Markdown files. Define your schema in a single YAML file. Get a fully navigable catalog with zero custom code.
+  title: Your architecture,<br/>browsable and beautiful
+  tagline: |
+    Turn plain Markdown files into an interactive architecture catalog.
+    One YAML schema. Zero custom code. Deploy anywhere.
   actions:
     - text: Get Started in 5 Minutes
-      link: /getting-started/introduction/
+      link: /getting-started/installation/
       icon: right-arrow
       variant: primary
     - text: Live Demo
       link: https://architecture-catalog.web.app
       icon: external
+      variant: minimal
     - text: GitHub
       link: https://github.com/ea-toolkit/architecture-catalog
       icon: external
+      variant: minimal
 ---
 
-import { Card, CardGrid, Aside } from '@astrojs/starlight/components';
+import { Card, CardGrid, Steps, Aside, LinkCard } from '@astrojs/starlight/components';
 
-<Aside type="tip">
-**See it live** — [architecture-catalog.web.app](https://architecture-catalog.web.app) shows a demo catalog with 6 domains and 180+ registered entities, including interactive context maps and event flow diagrams.
+## Get started in 3 steps
+
+<Steps>
+1. **Define your schema** — edit `registry-mapping.yaml` to declare element types, layers, relationships, and branding
+
+2. **Add your elements** — create Markdown files in `registry-v2/`. One file per architecture element, with YAML frontmatter
+
+3. **Build and browse** — run `npm run build`. The catalog reads your schema, scans your files, resolves cross-references, and generates a static site
+</Steps>
+
+<Aside type="tip" title="Works with any vocabulary">
+ArchiMate, TOGAF, C4, or your own custom terminology — the catalog adapts to whatever you define in the YAML schema. No hardcoded type names anywhere.
 </Aside>
 
-## Why Architecture Catalog?
+---
 
-<CardGrid stagger>
+## What you get
+
+<CardGrid>
   <Card title="Schema-driven" icon="setting">
-    One YAML file defines everything: element types, fields, relationships, layers, and branding. Zero hardcoded type names in the UI.
+    One YAML file defines everything — types, fields, relationships, layers, and branding. Add a new element type? Just add an entry. Zero code changes.
+  </Card>
+  <Card title="Interactive maps" icon="random">
+    Domain context maps, event flow diagrams, and capability heatmaps. Search, filter, focus mode, and PNG export — all powered by React Flow.
   </Card>
   <Card title="Plain Markdown" icon="document">
-    Each architecture element is a `.md` file with YAML frontmatter. No proprietary formats, no vendor lock-in. Git-friendly and AI-readable.
+    Each architecture element is a `.md` file with YAML frontmatter. No proprietary formats. Git-friendly, diff-friendly, AI-readable.
   </Card>
-  <Card title="Static site" icon="rocket">
-    Builds to pure static HTML with Astro. Deploy anywhere: GitHub Pages, S3, Netlify, or behind your VPN. No servers, no databases.
-  </Card>
-  <Card title="Interactive graphs" icon="random">
-    Domain context maps, event flow diagrams, and capability heatmaps powered by React Flow with automatic dagre layout. Search, filter, focus mode, and PNG export.
+  <Card title="Deploy anywhere" icon="rocket">
+    Builds to pure static HTML. GitHub Pages, S3, Firebase, Netlify, or behind your VPN. No servers, no databases, no runtime dependencies.
   </Card>
 </CardGrid>
 
-## 3 Steps to Your Architecture Catalog
+---
+
+## Explore the docs
 
 <CardGrid>
-  <Card title="1. Define your schema" icon="document">
-    Edit `registry-mapping.yaml` — declare your element types, layers, relationships, and branding. Use ArchiMate, C4, TOGAF, or your own vocabulary.
-  </Card>
-  <Card title="2. Add your elements" icon="add-document">
-    Create Markdown files in `registry-v2/`. One file per architecture element. Copy a `_template.md`, fill in the YAML frontmatter.
-  </Card>
-  <Card title="3. Build and browse" icon="rocket">
-    Run `npm run build` — the loader reads your schema, scans your files, resolves cross-references, and generates a fully navigable static site.
-  </Card>
+  <LinkCard title="Introduction" description="What it is and why it exists" href="/getting-started/introduction/" />
+  <LinkCard title="Features" description="Dashboard, context maps, event flows, diagrams" href="/features/dashboard/" />
+  <LinkCard title="Modeling guide" description="Schema, elements, relationships, domains" href="/modeling/registry-mapping/" />
+  <LinkCard title="Deployment" description="Build, preview, and deploy to any static host" href="/deployment/build-and-deploy/" />
 </CardGrid>

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -5,16 +5,23 @@ template: splash
 hero:
   tagline: Model your enterprise architecture using plain Markdown files. Define your schema in a single YAML file. Get a fully navigable catalog with zero custom code.
   actions:
-    - text: Get Started
+    - text: Get Started in 5 Minutes
       link: /getting-started/introduction/
       icon: right-arrow
       variant: primary
-    - text: View on GitHub
+    - text: Live Demo
+      link: https://architecture-catalog.web.app
+      icon: external
+    - text: GitHub
       link: https://github.com/ea-toolkit/architecture-catalog
       icon: external
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import { Card, CardGrid, Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip">
+**See it live** — [architecture-catalog.web.app](https://architecture-catalog.web.app) shows a demo catalog with 6 domains and 180+ registered entities, including interactive context maps and event flow diagrams.
+</Aside>
 
 ## Why Architecture Catalog?
 
@@ -29,6 +36,20 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     Builds to pure static HTML with Astro. Deploy anywhere: GitHub Pages, S3, Netlify, or behind your VPN. No servers, no databases.
   </Card>
   <Card title="Interactive graphs" icon="random">
-    Dependency graphs powered by React Flow with automatic dagre layout. Search, filter, export to PNG.
+    Domain context maps, event flow diagrams, and capability heatmaps powered by React Flow with automatic dagre layout. Search, filter, focus mode, and PNG export.
+  </Card>
+</CardGrid>
+
+## 3 Steps to Your Architecture Catalog
+
+<CardGrid>
+  <Card title="1. Define your schema" icon="document">
+    Edit `registry-mapping.yaml` — declare your element types, layers, relationships, and branding. Use ArchiMate, C4, TOGAF, or your own vocabulary.
+  </Card>
+  <Card title="2. Add your elements" icon="add-document">
+    Create Markdown files in `registry-v2/`. One file per architecture element. Copy a `_template.md`, fill in the YAML frontmatter.
+  </Card>
+  <Card title="3. Build and browse" icon="rocket">
+    Run `npm run build` — the loader reads your schema, scans your files, resolves cross-references, and generates a fully navigable static site.
   </Card>
 </CardGrid>

--- a/docs-site/src/content/docs/tools/claude-skills.md
+++ b/docs-site/src/content/docs/tools/claude-skills.md
@@ -3,26 +3,39 @@ title: Claude Skills
 description: AI-assisted architecture management with Claude Code.
 ---
 
-The project includes Claude Code skills (slash commands) for AI-assisted architecture work.
+The project includes [Claude Code](https://claude.com/claude-code) skills (slash commands) for AI-assisted architecture work.
 
 ## Available skills
 
 | Skill | Usage | Purpose |
 |-------|-------|---------|
-| `/example-archi` | `/example-archi [question]` | Example domain Q&A, create entries, proposals |
+| `/enterprise-platform-archi` | `/enterprise-platform-archi [question]` | Enterprise Platform domain Q&A, create entries, proposals |
 | `/validate` | `/validate` | Run model validation, show errors and orphans |
 | `/dashboard` | `/dashboard` | Generate HTML health dashboard |
 | `/new-entry` | `/new-entry [type] [name]` | Create registry entry (guided wizard) |
+| `/scaffold-component` | `/scaffold-component [Name]` | Scaffold React component + test file |
 
 ## Examples
 
 ```
-/example-archi What data does Tenant Management own?
-/example-archi Create a registry entry for Payment Gateway
+/enterprise-platform-archi What data does Tenant Management own?
+/enterprise-platform-archi Create a registry entry for Payment Gateway
 /validate
 /dashboard
 /new-entry data-object "Payment Record"
+/scaffold-component CapabilityHeatmap
 ```
+
+## Specialized agents
+
+The project also includes auto-delegating agents that Claude Code uses when appropriate:
+
+| Agent | Scope | Purpose |
+|-------|-------|---------|
+| `domain-expert` | Read-only | Domain Q&A — answers questions about specific domains |
+| `fe-developer` | Read/Write `catalog-ui/` | Frontend development tasks |
+| `registry-agent` | Read/Write `registry-v2/`, `views/` | Registry data creation and validation |
+| `test-writer` | Read/Write test files | Test creation (Vitest + pytest) |
 
 ## How skills work
 
@@ -37,7 +50,7 @@ Each skill is defined in `.claude/skills/<name>/SKILL.md`. When invoked, the ski
 The pattern is `/<domain>-archi`. To add a new domain skill:
 
 1. Create `.claude/skills/<domain>-archi/SKILL.md`
-2. Follow the template from the existing `example-archi` skill
+2. Follow the template from the existing `enterprise-platform-archi` skill
 3. Scope the search to your domain's registry files
 
 This gives each domain team a dedicated AI assistant that knows their architecture.

--- a/docs-site/src/content/docs/tools/validation.md
+++ b/docs-site/src/content/docs/tools/validation.md
@@ -15,8 +15,8 @@ npm run build
 The build output shows a health summary:
 
 ```
-Registry loaded: 32 elements, 69 edges
-  Healthy: 32  |  Connected: 32  |  Orphans: 0
+Registry loaded: 182 elements, 340 edges
+  Healthy: 182  |  Connected: 182  |  Orphans: 0
   Broken refs: 0  |  Missing type: 0
 ```
 

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -1,0 +1,117 @@
+/* ── Architecture Catalog Docs — Custom Theme ──
+   Matches the catalog-ui design language:
+   - Inter font
+   - Blue accent (#3b82f6)
+   - Slate dark palette
+   - Dark mode default
+*/
+
+/* ── Accent colors ── */
+:root {
+  --sl-color-accent-low: #1e3a5f;
+  --sl-color-accent: #3b82f6;
+  --sl-color-accent-high: #93c5fd;
+  --sl-font: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --sl-font-mono: 'JetBrains Mono', ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+}
+
+:root[data-theme='light'] {
+  --sl-color-accent-low: #dbeafe;
+  --sl-color-accent: #2563eb;
+  --sl-color-accent-high: #1e3a5f;
+}
+
+/* ── Splash hero page ── */
+.hero {
+  padding-block: 4rem !important;
+}
+
+.hero .tagline {
+  font-size: var(--sl-text-lg) !important;
+  max-width: 42ch;
+  line-height: 1.6;
+  color: var(--sl-color-gray-3);
+}
+
+:root[data-theme='light'] .hero .tagline {
+  color: var(--sl-color-gray-4);
+}
+
+/* Hero title — larger and weighted */
+.hero .hero-title {
+  font-size: var(--sl-text-5xl) !important;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+/* Hero action buttons — catalog-style */
+.hero .action {
+  border-radius: 8px !important;
+  font-weight: 600 !important;
+  padding: 0.65rem 1.5rem !important;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.hero .action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.hero .action.primary {
+  background: var(--sl-color-accent) !important;
+  border-color: var(--sl-color-accent) !important;
+}
+
+/* ── Card grid — polished cards ── */
+.card {
+  border-radius: 10px !important;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.card .card-title {
+  font-weight: 700;
+}
+
+/* ── Sidebar polish ── */
+nav.sidebar .top-level > li > details > summary,
+nav.sidebar .top-level > li > a {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+/* ── Header polish ── */
+.header {
+  backdrop-filter: blur(12px);
+}
+
+/* ── Code blocks ── */
+pre {
+  border-radius: 8px !important;
+  border: 1px solid var(--sl-color-gray-5) !important;
+}
+
+/* ── Tip/note callouts — match catalog accent ── */
+.starlight-aside--tip {
+  border-color: var(--sl-color-accent);
+}
+
+/* ── Splash page specific: full-width cards ── */
+[data-page-type='splash'] .sl-container {
+  max-width: 72rem;
+}
+
+/* ── Footer / bottom nav ── */
+.pagination-links a {
+  border-radius: 8px !important;
+  transition: border-color 0.15s;
+}
+
+.pagination-links a:hover {
+  border-color: var(--sl-color-accent) !important;
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,13 +1,26 @@
 {
-  "hosting": {
-    "site": "architecture-catalog",
-    "public": "catalog-ui/dist",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
-    "cleanUrls": true,
-    "trailingSlash": false
-  }
+  "hosting": [
+    {
+      "target": "catalog",
+      "public": "catalog-ui/dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "cleanUrls": true,
+      "trailingSlash": false
+    },
+    {
+      "target": "docs",
+      "public": "docs-site/dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "cleanUrls": true,
+      "trailingSlash": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- **5 new feature pages** — Dashboard, Domain Overview, Context Map, Event Flow Map, Diagrams with video placeholders for upcoming recordings
- **Docs site deployed** to [docs-architecture-catalog.web.app](https://docs-architecture-catalog.web.app)
- **Multi-site Firebase Hosting** — catalog + docs deployed together via CI/CD
- **Docs link** added to catalog UI icon bar (book icon)
- **Updated content** — branding docs with `company` field, stats updated to 182 elements, claude-skills page with actual names

## Sites
- Catalog: https://architecture-catalog.web.app
- Docs: https://docs-architecture-catalog.web.app

## Test plan
- [x] Docs site builds (25 pages)
- [x] Catalog builds (286 pages)
- [x] 81/81 vitest tests pass
- [x] Both sites deployed and verified
- [ ] Manual: docs sidebar shows new Features section
- [ ] Manual: catalog icon bar shows docs link

🤖 Generated with [Claude Code](https://claude.com/claude-code)