### PR TITLE
feat: add cross-domain architecture landscape view

### DIFF
--- a/catalog-ui/src/components/graphs/CrossDomainMap.tsx
+++ b/catalog-ui/src/components/graphs/CrossDomainMap.tsx
@@ -1,6 +1,7 @@
 // catalog-ui/src/components/graphs/CrossDomainMap.tsx
 // Architecture Landscape — cross-domain high-level view
 // Shows domains as nodes, inter-domain relationships as weighted edges
+// Users can toggle domains on/off to manage complexity at scale
 
 import React, { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { toPng } from 'html-to-image';
@@ -59,9 +60,59 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [isLayoutReady, setIsLayoutReady] = useState(false);
 
-  // Build and layout graph on mount
+  // Domain selection — all selected by default
+  const [selectedDomains, setSelectedDomains] = useState<Set<string>>(
+    () => new Set(domains.map(d => d.id))
+  );
+
+  // Track layout generation to trigger fitView
+  const [layoutVersion, setLayoutVersion] = useState(0);
+
+  // Filter domains and edges based on selection
+  const filteredDomains = useMemo(() =>
+    domains.filter(d => selectedDomains.has(d.id)),
+    [domains, selectedDomains]
+  );
+
+  const filteredEdges = useMemo(() =>
+    crossDomainEdges.filter(e =>
+      selectedDomains.has(e.sourceDomain) && selectedDomains.has(e.targetDomain)
+    ),
+    [crossDomainEdges, selectedDomains]
+  );
+
+  // Toggle a domain on/off
+  const toggleDomain = useCallback((domainId: string) => {
+    setSelectedDomains(prev => {
+      const next = new Set(prev);
+      if (next.has(domainId)) {
+        next.delete(domainId);
+      } else {
+        next.add(domainId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Select all / clear all
+  const selectAll = useCallback(() => {
+    setSelectedDomains(new Set(domains.map(d => d.id)));
+  }, [domains]);
+
+  const clearAll = useCallback(() => {
+    setSelectedDomains(new Set());
+  }, []);
+
+  // Build and layout graph when selection changes
   useEffect(() => {
-    const { nodes: rawNodes, edges: rawEdges } = buildCrossDomainGraph(domains, crossDomainEdges);
+    if (filteredDomains.length === 0) {
+      setNodes([]);
+      setEdges([]);
+      setIsLayoutReady(true);
+      return;
+    }
+
+    const { nodes: rawNodes, edges: rawEdges } = buildCrossDomainGraph(filteredDomains, filteredEdges);
     const layouted = applyDagreLayout(rawNodes, rawEdges, {
       direction: 'TB',
       ranksep: 250,
@@ -72,15 +123,16 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
     setNodes(layouted.nodes);
     setEdges(layouted.edges);
     setIsLayoutReady(true);
-  }, [domains, crossDomainEdges, setNodes, setEdges]);
+    setLayoutVersion(v => v + 1);
+  }, [filteredDomains, filteredEdges, setNodes, setEdges]);
 
-  // Fit view when layout is ready
+  // Fit view when layout changes
   useEffect(() => {
-    if (isLayoutReady) {
+    if (isLayoutReady && layoutVersion > 0) {
       const timer = setTimeout(() => fitView({ padding: 0.2 }), 100);
       return () => clearTimeout(timer);
     }
-  }, [isLayoutReady, fitView]);
+  }, [isLayoutReady, layoutVersion, fitView]);
 
   // Navigate to domain context map on click
   const onNodeClick: NodeMouseHandler = useCallback((event, node) => {
@@ -111,20 +163,11 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
     });
   }, []);
 
-  // Legend items from domains
-  const legendItems = useMemo(() => {
-    return domains.map(d => ({
-      name: d.name,
-      color: d.color,
-      count: d.totalElements,
-    }));
-  }, [domains]);
-
-  // Integration category legend — deduplicate from all edges
+  // Integration category legend — deduplicate from visible edges
   const integrationCategories = useMemo(() => {
     const seen = new Set<string>();
     const categories: string[] = [];
-    for (const edge of crossDomainEdges) {
+    for (const edge of filteredEdges) {
       for (const integration of edge.integrations) {
         if (!seen.has(integration.category)) {
           seen.add(integration.category);
@@ -133,18 +176,10 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
       }
     }
     return categories;
-  }, [crossDomainEdges]);
-
-  if (!isLayoutReady) {
-    return (
-      <div style={{ width: '100%', height: '100%', minHeight: 400, background: '#fafafa', borderRadius: 12, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#94a3b8' }}>
-        Loading landscape...
-      </div>
-    );
-  }
+  }, [filteredEdges]);
 
   return (
-    <div ref={graphContainerRef} style={{ width: '100%', height: '100%', minHeight: 400, position: 'relative', background: '#fafafa', borderRadius: 12, overflow: 'hidden' }}>
+    <div ref={graphContainerRef} style={{ width: '100%', height: '100%', minHeight: 400, position: 'relative', background: '#fafafa', borderRadius: 0, overflow: 'hidden' }}>
       <EdgeMarkerDefs />
 
       <ReactFlow
@@ -164,66 +199,101 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
         <Background color="var(--graph-grid, #e2e8f0)" gap={20} />
         <Controls position="top-left" showInteractive={false} />
 
-        {/* Export button */}
+        {/* Domain selector + export */}
         <Panel position="top-right">
-          <button
-            onClick={handleExportPng}
-            title="Export as PNG"
-            className="graph-panel-btn"
-            style={{ display: 'flex', alignItems: 'center', gap: 3 }}
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
-              <polyline points="7 10 12 15 17 10" />
-              <line x1="12" y1="15" x2="12" y2="3" />
-            </svg>
-            PNG
-          </button>
-        </Panel>
-
-        {/* Legend */}
-        <Panel position="bottom-right">
-          <div className="graph-panel-box" style={{
-            padding: '10px 14px',
-            fontSize: 11,
-            maxWidth: 200,
-          }}>
-            <div className="graph-panel-heading">Domains</div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              {legendItems.map(item => (
-                <div key={item.name} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <span style={{
-                    width: 10,
-                    height: 10,
-                    borderRadius: 2,
-                    background: item.color,
-                    flexShrink: 0,
-                  }} />
-                  <span className="graph-panel-label" style={{ flex: 1 }}>{item.name}</span>
-                  <span style={{ fontSize: 10, color: 'var(--graph-panel-muted, #94a3b8)' }}>{item.count}</span>
-                </div>
-              ))}
+          <div className="graph-panel-box landscape-domain-selector" style={{ padding: '10px 14px', fontSize: 11 }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+              <div className="graph-panel-heading" style={{ margin: 0 }}>Domains</div>
+              <div style={{ display: 'flex', gap: 6 }}>
+                <button
+                  onClick={selectAll}
+                  className="graph-panel-btn"
+                  style={{ fontSize: 10, padding: '2px 6px' }}
+                >
+                  All
+                </button>
+                <button
+                  onClick={clearAll}
+                  className="graph-panel-btn"
+                  style={{ fontSize: 10, padding: '2px 6px' }}
+                >
+                  None
+                </button>
+                <div style={{ width: 1, background: 'var(--graph-panel-divider, #e2e8f0)', margin: '0 2px' }} />
+                <button
+                  onClick={handleExportPng}
+                  title="Export as PNG"
+                  className="graph-panel-btn"
+                  style={{ display: 'flex', alignItems: 'center', gap: 3, fontSize: 10, padding: '2px 6px' }}
+                >
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                  PNG
+                </button>
+              </div>
             </div>
-            {integrationCategories.length > 0 && (
-              <>
-                <div className="graph-panel-divider" />
-                <div className="graph-panel-heading">Integration Types</div>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                  {integrationCategories.map(cat => (
-                    <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                      <IntegrationIcon category={cat} />
-                      <span className="graph-panel-label">{cat}</span>
-                    </div>
-                  ))}
-                </div>
-              </>
-            )}
-            <div className="graph-panel-divider" />
-            <div style={{ fontSize: 10, color: 'var(--graph-panel-muted, #94a3b8)' }}>
-              {crossDomainEdges.length} domain connections
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+              {domains.map(d => {
+                const isSelected = selectedDomains.has(d.id);
+                return (
+                  <button
+                    key={d.id}
+                    onClick={() => toggleDomain(d.id)}
+                    className={`landscape-domain-chip ${isSelected ? 'landscape-domain-chip--active' : ''}`}
+                    style={{
+                      '--chip-color': d.color,
+                    } as React.CSSProperties}
+                  >
+                    <span className="landscape-domain-chip-dot" style={{ background: d.color }} />
+                    {d.name}
+                  </button>
+                );
+              })}
+            </div>
+            <div style={{ marginTop: 8, fontSize: 10, color: 'var(--graph-panel-muted, #94a3b8)' }}>
+              {filteredDomains.length} of {domains.length} domains · {filteredEdges.length} connections
             </div>
           </div>
         </Panel>
+
+        {/* Legend — integration types */}
+        {integrationCategories.length > 0 && (
+          <Panel position="bottom-right">
+            <div className="graph-panel-box" style={{ padding: '10px 14px', fontSize: 11, maxWidth: 200 }}>
+              <div className="graph-panel-heading">Integration Types</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {integrationCategories.map(cat => (
+                  <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <IntegrationIcon category={cat} />
+                    <span className="graph-panel-label">{cat}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Panel>
+        )}
+
+        {/* Empty state */}
+        {filteredDomains.length === 0 && (
+          <Panel position="top-left" style={{ top: 60 }}>
+            <div style={{
+              padding: '24px 32px',
+              color: 'var(--graph-panel-muted, #94a3b8)',
+              fontSize: 13,
+              textAlign: 'center',
+            }}>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ margin: '0 auto 8px', display: 'block', opacity: 0.5 }}>
+                <circle cx="12" cy="12" r="10"/>
+                <line x1="2" y1="12" x2="22" y2="12"/>
+                <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+              </svg>
+              Select domains to view their integrations
+            </div>
+          </Panel>
+        )}
       </ReactFlow>
     </div>
   );

--- a/catalog-ui/src/components/graphs/CrossDomainMap.tsx
+++ b/catalog-ui/src/components/graphs/CrossDomainMap.tsx
@@ -33,15 +33,13 @@ const edgeTypes = { relationshipEdge: RelationshipEdge };
 function IntegrationIcon({ category }: { category: string }) {
   const style = { width: 14, height: 14, flexShrink: 0 as const, color: 'var(--graph-panel-text, #475569)' };
   switch (category) {
-    case 'API':
+    case 'API Integration':
       return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M4 4h16v16H4z" /><path d="M4 9h16" /><path d="M9 4v16" /></svg>;
-    case 'Events':
+    case 'Event Coupling':
       return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" /></svg>;
-    case 'Data':
+    case 'Data Access':
       return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><ellipse cx="12" cy="6" rx="8" ry="3" /><path d="M4 6v6c0 1.66 3.58 3 8 3s8-1.34 8-3V6" /><path d="M4 12v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6" /></svg>;
-    case 'Service':
-      return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="2" y="3" width="20" height="14" rx="2" /><path d="M8 21h8" /><path d="M12 17v4" /></svg>;
-    case 'Infrastructure':
+    case 'Shared Infrastructure':
       return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="2" y="2" width="20" height="8" rx="2" /><rect x="2" y="14" width="20" height="8" rx="2" /><line x1="6" y1="6" x2="6.01" y2="6" /><line x1="6" y1="18" x2="6.01" y2="18" /></svg>;
     default:
       return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" /></svg>;

--- a/catalog-ui/src/components/graphs/CrossDomainMap.tsx
+++ b/catalog-ui/src/components/graphs/CrossDomainMap.tsx
@@ -24,7 +24,7 @@ import RelationshipEdge, { EdgeMarkerDefs } from './edges/RelationshipEdge';
 import { applyDagreLayout } from './utils/layout';
 import { buildCrossDomainGraph } from './utils/cross-domain-graph-data';
 import type { Domain } from '../../data/registry';
-import type { CrossDomainEdge } from '../../lib/cross-domain';
+import type { CrossDomainEdge, IntegrationPattern } from '../../lib/cross-domain';
 
 const nodeTypes = { baseNode: BaseNode };
 const edgeTypes = { relationshipEdge: RelationshipEdge };
@@ -103,6 +103,19 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
     }));
   }, [domains]);
 
+  // Integration category legend — deduplicate from all edges
+  const integrationCategories = useMemo(() => {
+    const seen = new Map<string, IntegrationPattern>();
+    for (const edge of crossDomainEdges) {
+      for (const integration of edge.integrations) {
+        if (!seen.has(integration.category)) {
+          seen.set(integration.category, integration);
+        }
+      }
+    }
+    return Array.from(seen.values());
+  }, [crossDomainEdges]);
+
   if (!isLayoutReady) {
     return (
       <div style={{ width: '100%', height: '100%', minHeight: 400, background: '#fafafa', borderRadius: 12, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#94a3b8' }}>
@@ -172,9 +185,23 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
                 </div>
               ))}
             </div>
+            {integrationCategories.length > 0 && (
+              <>
+                <div className="graph-panel-divider" />
+                <div className="graph-panel-heading">Integration Types</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  {integrationCategories.map(cat => (
+                    <div key={cat.category} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <span style={{ fontSize: 12, width: 16, textAlign: 'center' }}>{cat.icon}</span>
+                      <span className="graph-panel-label">{cat.category}</span>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
             <div className="graph-panel-divider" />
             <div style={{ fontSize: 10, color: 'var(--graph-panel-muted, #94a3b8)' }}>
-              {crossDomainEdges.length} cross-domain connections
+              {crossDomainEdges.length} domain connections
             </div>
           </div>
         </Panel>

--- a/catalog-ui/src/components/graphs/CrossDomainMap.tsx
+++ b/catalog-ui/src/components/graphs/CrossDomainMap.tsx
@@ -24,10 +24,29 @@ import RelationshipEdge, { EdgeMarkerDefs } from './edges/RelationshipEdge';
 import { applyDagreLayout } from './utils/layout';
 import { buildCrossDomainGraph } from './utils/cross-domain-graph-data';
 import type { Domain } from '../../data/registry';
-import type { CrossDomainEdge, IntegrationPattern } from '../../lib/cross-domain';
+import type { CrossDomainEdge } from '../../lib/cross-domain';
 
 const nodeTypes = { baseNode: BaseNode };
 const edgeTypes = { relationshipEdge: RelationshipEdge };
+
+// SVG icons for integration categories — matches the app's inline SVG style
+function IntegrationIcon({ category }: { category: string }) {
+  const style = { width: 14, height: 14, flexShrink: 0 as const, color: 'var(--graph-panel-text, #475569)' };
+  switch (category) {
+    case 'API':
+      return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M4 4h16v16H4z" /><path d="M4 9h16" /><path d="M9 4v16" /></svg>;
+    case 'Events':
+      return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" /></svg>;
+    case 'Data':
+      return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><ellipse cx="12" cy="6" rx="8" ry="3" /><path d="M4 6v6c0 1.66 3.58 3 8 3s8-1.34 8-3V6" /><path d="M4 12v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6" /></svg>;
+    case 'Service':
+      return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="2" y="3" width="20" height="14" rx="2" /><path d="M8 21h8" /><path d="M12 17v4" /></svg>;
+    case 'Infrastructure':
+      return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="2" y="2" width="20" height="8" rx="2" /><rect x="2" y="14" width="20" height="8" rx="2" /><line x1="6" y1="6" x2="6.01" y2="6" /><line x1="6" y1="18" x2="6.01" y2="18" /></svg>;
+    default:
+      return <svg {...style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" /></svg>;
+  }
+}
 
 interface CrossDomainMapProps {
   domains: Domain[];
@@ -105,15 +124,17 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
 
   // Integration category legend — deduplicate from all edges
   const integrationCategories = useMemo(() => {
-    const seen = new Map<string, IntegrationPattern>();
+    const seen = new Set<string>();
+    const categories: string[] = [];
     for (const edge of crossDomainEdges) {
       for (const integration of edge.integrations) {
         if (!seen.has(integration.category)) {
-          seen.set(integration.category, integration);
+          seen.add(integration.category);
+          categories.push(integration.category);
         }
       }
     }
-    return Array.from(seen.values());
+    return categories;
   }, [crossDomainEdges]);
 
   if (!isLayoutReady) {
@@ -191,9 +212,9 @@ function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps)
                 <div className="graph-panel-heading">Integration Types</div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                   {integrationCategories.map(cat => (
-                    <div key={cat.category} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                      <span style={{ fontSize: 12, width: 16, textAlign: 'center' }}>{cat.icon}</span>
-                      <span className="graph-panel-label">{cat.category}</span>
+                    <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <IntegrationIcon category={cat} />
+                      <span className="graph-panel-label">{cat}</span>
                     </div>
                   ))}
                 </div>

--- a/catalog-ui/src/components/graphs/CrossDomainMap.tsx
+++ b/catalog-ui/src/components/graphs/CrossDomainMap.tsx
@@ -1,0 +1,192 @@
+// catalog-ui/src/components/graphs/CrossDomainMap.tsx
+// Architecture Landscape — cross-domain high-level view
+// Shows domains as nodes, inter-domain relationships as weighted edges
+
+import React, { useCallback, useMemo, useState, useEffect, useRef } from 'react';
+import { toPng } from 'html-to-image';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+  ReactFlowProvider,
+  Panel,
+  type Node,
+  type Edge,
+  type NodeMouseHandler,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+
+import BaseNode from './nodes/BaseNode';
+import RelationshipEdge, { EdgeMarkerDefs } from './edges/RelationshipEdge';
+import { applyDagreLayout } from './utils/layout';
+import { buildCrossDomainGraph } from './utils/cross-domain-graph-data';
+import type { Domain } from '../../data/registry';
+import type { CrossDomainEdge } from '../../lib/cross-domain';
+
+const nodeTypes = { baseNode: BaseNode };
+const edgeTypes = { relationshipEdge: RelationshipEdge };
+
+interface CrossDomainMapProps {
+  domains: Domain[];
+  crossDomainEdges: CrossDomainEdge[];
+}
+
+function CrossDomainMapInner({ domains, crossDomainEdges }: CrossDomainMapProps) {
+  const { fitView } = useReactFlow();
+  const graphContainerRef = useRef<HTMLDivElement>(null);
+
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [isLayoutReady, setIsLayoutReady] = useState(false);
+
+  // Build and layout graph on mount
+  useEffect(() => {
+    const { nodes: rawNodes, edges: rawEdges } = buildCrossDomainGraph(domains, crossDomainEdges);
+    const layouted = applyDagreLayout(rawNodes, rawEdges, {
+      direction: 'TB',
+      ranksep: 250,
+      nodesep: 120,
+      nodeWidth: 280,
+      nodeHeight: 100,
+    });
+    setNodes(layouted.nodes);
+    setEdges(layouted.edges);
+    setIsLayoutReady(true);
+  }, [domains, crossDomainEdges, setNodes, setEdges]);
+
+  // Fit view when layout is ready
+  useEffect(() => {
+    if (isLayoutReady) {
+      const timer = setTimeout(() => fitView({ padding: 0.2 }), 100);
+      return () => clearTimeout(timer);
+    }
+  }, [isLayoutReady, fitView]);
+
+  // Navigate to domain context map on click
+  const onNodeClick: NodeMouseHandler = useCallback((event, node) => {
+    if ((event.target as HTMLElement).closest('a')) return;
+    const url = (node.data as Record<string, unknown>).catalogUrl as string;
+    if (url) window.location.href = url;
+  }, []);
+
+  // PNG export
+  const handleExportPng = useCallback(() => {
+    const viewport = graphContainerRef.current?.querySelector('.react-flow__viewport') as HTMLElement | null;
+    if (!viewport) return;
+
+    toPng(viewport, {
+      backgroundColor: '#fafafa',
+      pixelRatio: 2,
+      filter: (node) => {
+        if (node?.classList?.contains('react-flow__controls')) return false;
+        return true;
+      },
+    }).then((dataUrl) => {
+      const link = document.createElement('a');
+      link.download = 'architecture-landscape.png';
+      link.href = dataUrl;
+      link.click();
+    }).catch((err) => {
+      console.error('PNG export failed:', err);
+    });
+  }, []);
+
+  // Legend items from domains
+  const legendItems = useMemo(() => {
+    return domains.map(d => ({
+      name: d.name,
+      color: d.color,
+      count: d.totalElements,
+    }));
+  }, [domains]);
+
+  if (!isLayoutReady) {
+    return (
+      <div style={{ width: '100%', height: '100%', minHeight: 400, background: '#fafafa', borderRadius: 12, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#94a3b8' }}>
+        Loading landscape...
+      </div>
+    );
+  }
+
+  return (
+    <div ref={graphContainerRef} style={{ width: '100%', height: '100%', minHeight: 400, position: 'relative', background: '#fafafa', borderRadius: 12, overflow: 'hidden' }}>
+      <EdgeMarkerDefs />
+
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={onNodeClick}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        minZoom={0.3}
+        maxZoom={2}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background color="var(--graph-grid, #e2e8f0)" gap={20} />
+        <Controls position="top-left" showInteractive={false} />
+
+        {/* Export button */}
+        <Panel position="top-right">
+          <button
+            onClick={handleExportPng}
+            title="Export as PNG"
+            className="graph-panel-btn"
+            style={{ display: 'flex', alignItems: 'center', gap: 3 }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            PNG
+          </button>
+        </Panel>
+
+        {/* Legend */}
+        <Panel position="bottom-right">
+          <div className="graph-panel-box" style={{
+            padding: '10px 14px',
+            fontSize: 11,
+            maxWidth: 200,
+          }}>
+            <div className="graph-panel-heading">Domains</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              {legendItems.map(item => (
+                <div key={item.name} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span style={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: 2,
+                    background: item.color,
+                    flexShrink: 0,
+                  }} />
+                  <span className="graph-panel-label" style={{ flex: 1 }}>{item.name}</span>
+                  <span style={{ fontSize: 10, color: 'var(--graph-panel-muted, #94a3b8)' }}>{item.count}</span>
+                </div>
+              ))}
+            </div>
+            <div className="graph-panel-divider" />
+            <div style={{ fontSize: 10, color: 'var(--graph-panel-muted, #94a3b8)' }}>
+              {crossDomainEdges.length} cross-domain connections
+            </div>
+          </div>
+        </Panel>
+      </ReactFlow>
+    </div>
+  );
+}
+
+export default function CrossDomainMap(props: CrossDomainMapProps) {
+  return (
+    <ReactFlowProvider>
+      <CrossDomainMapInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/catalog-ui/src/components/graphs/edges/RelationshipEdge.tsx
+++ b/catalog-ui/src/components/graphs/edges/RelationshipEdge.tsx
@@ -12,6 +12,10 @@ import { getEdgeStyle } from '../utils/colors';
 
 export interface RelationshipEdgeData {
   relationship: string;
+  /** Custom label override — if set, takes priority over the style-derived label */
+  label?: string;
+  /** Tooltip text shown on hover */
+  tooltip?: string;
   showLabel?: boolean;
 }
 
@@ -30,6 +34,9 @@ export default function RelationshipEdge({
   const relationship = edgeData?.relationship || 'default';
   const style = getEdgeStyle(relationship);
   const showLabel = edgeData?.showLabel !== false;
+  // Custom label from data takes priority over style-derived label
+  const displayLabel = edgeData?.label || style.label;
+  const tooltip = edgeData?.tooltip;
 
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
@@ -52,9 +59,10 @@ export default function RelationshipEdge({
         }}
         markerEnd="url(#arrowhead)"
       />
-      {showLabel && style.label && (
+      {showLabel && displayLabel && (
         <EdgeLabelRenderer>
           <div
+            title={tooltip}
             style={{
               position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
@@ -65,12 +73,13 @@ export default function RelationshipEdge({
               fontWeight: 500,
               color: 'var(--edge-label-text, #475569)',
               border: '1px solid var(--edge-label-border, #cbd5e1)',
-              pointerEvents: 'none',
+              pointerEvents: tooltip ? 'auto' : 'none',
               whiteSpace: 'nowrap',
               boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+              cursor: tooltip ? 'help' : 'default',
             }}
           >
-            {style.label}
+            {displayLabel}
           </div>
         </EdgeLabelRenderer>
       )}

--- a/catalog-ui/src/components/graphs/edges/RelationshipEdge.tsx
+++ b/catalog-ui/src/components/graphs/edges/RelationshipEdge.tsx
@@ -1,7 +1,7 @@
 // catalog-ui/src/components/graphs/edges/RelationshipEdge.tsx
-// Custom edge component with relationship styling
+// Custom edge component with relationship styling and styled tooltips
 
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   BaseEdge,
   EdgeLabelRenderer,
@@ -14,8 +14,10 @@ export interface RelationshipEdgeData {
   relationship: string;
   /** Custom label override — if set, takes priority over the style-derived label */
   label?: string;
-  /** Tooltip text shown on hover */
+  /** Tooltip content — either plain text or structured integration data */
   tooltip?: string;
+  /** Structured tooltip data for rich rendering */
+  tooltipSections?: Array<{ category: string; items: Array<{ id: string; name: string } | string> }>;
   showLabel?: boolean;
 }
 
@@ -34,9 +36,26 @@ export default function RelationshipEdge({
   const relationship = edgeData?.relationship || 'default';
   const style = getEdgeStyle(relationship);
   const showLabel = edgeData?.showLabel !== false;
-  // Custom label from data takes priority over style-derived label
   const displayLabel = edgeData?.label || style.label;
-  const tooltip = edgeData?.tooltip;
+  const tooltipSections = edgeData?.tooltipSections;
+  const hasTooltip = tooltipSections && tooltipSections.length > 0;
+
+  const [showTooltip, setShowTooltip] = useState(false);
+  const hideTimeout = useRef<ReturnType<typeof setTimeout>>();
+
+  const handleMouseEnter = () => {
+    if (!hasTooltip) return;
+    clearTimeout(hideTimeout.current);
+    setShowTooltip(true);
+  };
+
+  const handleMouseLeave = () => {
+    hideTimeout.current = setTimeout(() => setShowTooltip(false), 150);
+  };
+
+  useEffect(() => {
+    return () => clearTimeout(hideTimeout.current);
+  }, []);
 
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
@@ -62,24 +81,58 @@ export default function RelationshipEdge({
       {showLabel && displayLabel && (
         <EdgeLabelRenderer>
           <div
-            title={tooltip}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
             style={{
               position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
               background: 'var(--edge-label-bg, rgba(255,255,255,0.95))',
               padding: '3px 8px',
-              borderRadius: 4,
+              borderRadius: 0,
               fontSize: 11,
               fontWeight: 500,
               color: 'var(--edge-label-text, #475569)',
               border: '1px solid var(--edge-label-border, #cbd5e1)',
-              pointerEvents: tooltip ? 'auto' : 'none',
+              pointerEvents: hasTooltip ? 'auto' : 'none',
               whiteSpace: 'nowrap',
-              boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
-              cursor: tooltip ? 'help' : 'default',
+              cursor: hasTooltip ? 'pointer' : 'default',
             }}
           >
             {displayLabel}
+
+            {/* Custom styled tooltip */}
+            {hasTooltip && showTooltip && (
+              <div
+                className="edge-tooltip"
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+              >
+                {tooltipSections.map((section) => (
+                  <div key={section.category} className="edge-tooltip-section">
+                    <div className="edge-tooltip-category">{section.category}</div>
+                    {section.items.map((item) => {
+                      const isLinked = typeof item === 'object' && item.id;
+                      const name = typeof item === 'string' ? item : item.name;
+                      const key = typeof item === 'string' ? item : item.id;
+                      return (
+                        <div key={key} className="edge-tooltip-item">
+                          <span className="edge-tooltip-arrow">&rarr;</span>
+                          {isLinked ? (
+                            <a
+                              href={`/catalog/${(item as { id: string }).id}`}
+                              className="edge-tooltip-link"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              {name}
+                            </a>
+                          ) : name}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </EdgeLabelRenderer>
       )}

--- a/catalog-ui/src/components/graphs/index.ts
+++ b/catalog-ui/src/components/graphs/index.ts
@@ -2,6 +2,7 @@
 // Export all graph components
 
 export { default as DomainContextMap } from './DomainContextMap';
+export { default as CrossDomainMap } from './CrossDomainMap';
 export { default as ElementContextGraph } from './ElementContextGraph';
 export { default as BaseNode } from './nodes/BaseNode';
 export { default as RelationshipEdge, EdgeMarkerDefs } from './edges/RelationshipEdge';
@@ -9,5 +10,6 @@ export { default as RelationshipEdge, EdgeMarkerDefs } from './edges/Relationshi
 // Utils
 export { applyDagreLayout, getGraphBounds } from './utils/layout';
 export { buildDomainGraph, buildFocusGraph, buildElementGraph } from './utils/graph-data';
+export { buildCrossDomainGraph } from './utils/cross-domain-graph-data';
 export { NODE_STYLES, EDGE_STYLES, getNodeStyle, getEdgeStyle } from './utils/colors';
 export type { NodeStyle, EdgeStyle } from './utils/colors';

--- a/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
+++ b/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
@@ -8,6 +8,38 @@ import type { CrossDomainEdge } from '../../../lib/cross-domain';
 import { NODE_STYLES } from './colors';
 
 /**
+ * Build a readable label for the edge showing top relationship types.
+ * e.g., "serves (5), accesses (3)" or "14 relationships" for many types
+ */
+function buildEdgeLabel(edge: CrossDomainEdge): string {
+  const counts = edge.typeCounts;
+  if (counts.length <= 2) {
+    // Show all types with counts
+    return counts
+      .map(c => `${c.type.replace(/-/g, ' ')} (${c.count})`)
+      .join(', ');
+  }
+  // Show top 2 types + remaining count
+  const top = counts.slice(0, 2);
+  const rest = edge.weight - top.reduce((s, c) => s + c.count, 0);
+  const label = top.map(c => `${c.type.replace(/-/g, ' ')} (${c.count})`).join(', ');
+  return rest > 0 ? `${label} +${rest} more` : label;
+}
+
+/**
+ * Build a tooltip showing the full breakdown of relationship types.
+ * e.g., "serves: 5\naccesses: 3\ncomposition: 2"
+ */
+function buildEdgeTooltip(edge: CrossDomainEdge): string {
+  const lines = edge.typeCounts.map(c =>
+    `${c.type.replace(/-/g, ' ')}: ${c.count}`
+  );
+  lines.push(`─────────`);
+  lines.push(`Total: ${edge.weight} relationships`);
+  return lines.join('\n');
+}
+
+/**
  * Build ReactFlow graph showing domains as nodes and inter-domain
  * relationships as weighted edges.
  */
@@ -18,7 +50,7 @@ export function buildCrossDomainGraph(
   const nodes: Node[] = [];
   const edges: Edge[] = [];
 
-  // Domain nodes — larger than element nodes, using domain style
+  // Domain nodes — using domain style with per-domain color
   const domainStyle = NODE_STYLES['domain'] ?? {
     bg: '#eff6ff', border: '#3b82f6', text: '#1e40af',
     borderStyle: 'solid', borderRadius: '12px', icon: 'D',
@@ -40,12 +72,9 @@ export function buildCrossDomainGraph(
     });
   }
 
-  // Cross-domain edges with weight labels
+  // Cross-domain edges with descriptive labels and tooltips
   for (const edge of crossDomainEdges) {
     const edgeId = `${edge.sourceDomain}--${edge.targetDomain}`;
-    const label = edge.weight === 1
-      ? '1 relationship'
-      : `${edge.weight} relationships`;
 
     edges.push({
       id: edgeId,
@@ -55,7 +84,8 @@ export function buildCrossDomainGraph(
       animated: true,
       data: {
         relationship: 'cross-domain',
-        label,
+        label: buildEdgeLabel(edge),
+        tooltip: buildEdgeTooltip(edge),
       },
     });
   }

--- a/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
+++ b/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
@@ -9,26 +9,23 @@ import { NODE_STYLES } from './colors';
 
 /**
  * Build edge label from integration patterns.
- * Shows categories with counts: "API (5) · Events (3)"
+ * Shows categories with unique target counts: "API (4) · Events (3)"
+ * Uses target count (not edge count) so the number matches the tooltip items.
  */
 function buildEdgeLabel(edge: CrossDomainEdge): string {
   return edge.integrations
-    .map(i => `${i.category} (${i.count})`)
+    .map(i => `${i.category} (${i.targets.length})`)
     .join(' · ');
 }
 
 /**
- * Build tooltip showing the actual element names per category.
+ * Build structured tooltip sections with linkable targets.
  */
-function buildEdgeTooltip(edge: CrossDomainEdge): string {
-  const sections: string[] = [];
-  for (const i of edge.integrations) {
-    sections.push(`${i.category}:`);
-    for (const name of i.targetNames) {
-      sections.push(`  → ${name}`);
-    }
-  }
-  return sections.join('\n');
+function buildTooltipSections(edge: CrossDomainEdge): Array<{ category: string; items: Array<{ id: string; name: string }> }> {
+  return edge.integrations.map(i => ({
+    category: i.category,
+    items: i.targets,
+  }));
 }
 
 /**
@@ -80,7 +77,7 @@ export function buildCrossDomainGraph(
       data: {
         relationship: 'cross-domain',
         label: buildEdgeLabel(edge),
-        tooltip: buildEdgeTooltip(edge),
+        tooltipSections: buildTooltipSections(edge),
       },
     });
   }

--- a/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
+++ b/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
@@ -18,16 +18,17 @@ function buildEdgeLabel(edge: CrossDomainEdge): string {
 }
 
 /**
- * Build tooltip showing the full integration breakdown.
+ * Build tooltip showing the actual element names per category.
  */
 function buildEdgeTooltip(edge: CrossDomainEdge): string {
-  const lines = edge.integrations.map(i =>
-    `${i.category}: ${i.count} dependencies`
-  );
-  lines.push('');
-  lines.push(`Total: ${edge.totalWeight} integration dependencies`);
-  lines.push('(structural relationships excluded)');
-  return lines.join('\n');
+  const sections: string[] = [];
+  for (const i of edge.integrations) {
+    sections.push(`${i.category}:`);
+    for (const name of i.targetNames) {
+      sections.push(`  → ${name}`);
+    }
+  }
+  return sections.join('\n');
 }
 
 /**

--- a/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
+++ b/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
@@ -1,0 +1,64 @@
+// catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
+// Transform domain + cross-domain edge data → ReactFlow nodes/edges
+// for the Architecture Landscape view
+
+import type { Node, Edge } from '@xyflow/react';
+import type { Domain } from '../../../data/registry';
+import type { CrossDomainEdge } from '../../../lib/cross-domain';
+import { NODE_STYLES } from './colors';
+
+/**
+ * Build ReactFlow graph showing domains as nodes and inter-domain
+ * relationships as weighted edges.
+ */
+export function buildCrossDomainGraph(
+  domains: Domain[],
+  crossDomainEdges: CrossDomainEdge[]
+): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  // Domain nodes — larger than element nodes, using domain style
+  const domainStyle = NODE_STYLES['domain'] ?? {
+    bg: '#eff6ff', border: '#3b82f6', text: '#1e40af',
+    borderStyle: 'solid', borderRadius: '12px', icon: 'D',
+  };
+
+  for (const domain of domains) {
+    nodes.push({
+      id: domain.id,
+      type: 'baseNode',
+      position: { x: 0, y: 0 },
+      data: {
+        label: domain.name,
+        type: 'domain',
+        elementType: `${domain.totalElements} elements`,
+        catalogUrl: `/domains/${domain.id}/context-map`,
+        color: domain.color,
+        style: { ...domainStyle, border: domain.color },
+      },
+    });
+  }
+
+  // Cross-domain edges with weight labels
+  for (const edge of crossDomainEdges) {
+    const edgeId = `${edge.sourceDomain}--${edge.targetDomain}`;
+    const label = edge.weight === 1
+      ? '1 relationship'
+      : `${edge.weight} relationships`;
+
+    edges.push({
+      id: edgeId,
+      source: edge.sourceDomain,
+      target: edge.targetDomain,
+      type: 'relationshipEdge',
+      animated: true,
+      data: {
+        relationship: 'cross-domain',
+        label,
+      },
+    });
+  }
+
+  return { nodes, edges };
+}

--- a/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
+++ b/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
@@ -1,5 +1,5 @@
 // catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
-// Transform domain + cross-domain edge data → ReactFlow nodes/edges
+// Transform domain + cross-domain integration data → ReactFlow nodes/edges
 // for the Architecture Landscape view
 
 import type { Node, Edge } from '@xyflow/react';
@@ -8,40 +8,31 @@ import type { CrossDomainEdge } from '../../../lib/cross-domain';
 import { NODE_STYLES } from './colors';
 
 /**
- * Build a readable label for the edge showing top relationship types.
- * e.g., "serves (5), accesses (3)" or "14 relationships" for many types
+ * Build edge label from integration patterns.
+ * Shows icons + categories: "🔌 API (5)  ⚡ Events (3)"
  */
 function buildEdgeLabel(edge: CrossDomainEdge): string {
-  const counts = edge.typeCounts;
-  if (counts.length <= 2) {
-    // Show all types with counts
-    return counts
-      .map(c => `${c.type.replace(/-/g, ' ')} (${c.count})`)
-      .join(', ');
-  }
-  // Show top 2 types + remaining count
-  const top = counts.slice(0, 2);
-  const rest = edge.weight - top.reduce((s, c) => s + c.count, 0);
-  const label = top.map(c => `${c.type.replace(/-/g, ' ')} (${c.count})`).join(', ');
-  return rest > 0 ? `${label} +${rest} more` : label;
+  return edge.integrations
+    .map(i => `${i.icon} ${i.category} (${i.count})`)
+    .join('  ');
 }
 
 /**
- * Build a tooltip showing the full breakdown of relationship types.
- * e.g., "serves: 5\naccesses: 3\ncomposition: 2"
+ * Build tooltip showing the full integration breakdown.
  */
 function buildEdgeTooltip(edge: CrossDomainEdge): string {
-  const lines = edge.typeCounts.map(c =>
-    `${c.type.replace(/-/g, ' ')}: ${c.count}`
+  const lines = edge.integrations.map(i =>
+    `${i.icon} ${i.category}: ${i.count} element-level dependencies`
   );
-  lines.push(`─────────`);
-  lines.push(`Total: ${edge.weight} relationships`);
+  lines.push('');
+  lines.push(`Total: ${edge.totalWeight} integration dependencies`);
+  lines.push('(structural relationships excluded)');
   return lines.join('\n');
 }
 
 /**
  * Build ReactFlow graph showing domains as nodes and inter-domain
- * relationships as weighted edges.
+ * integration dependencies as edges.
  */
 export function buildCrossDomainGraph(
   domains: Domain[],
@@ -50,7 +41,6 @@ export function buildCrossDomainGraph(
   const nodes: Node[] = [];
   const edges: Edge[] = [];
 
-  // Domain nodes — using domain style with per-domain color
   const domainStyle = NODE_STYLES['domain'] ?? {
     bg: '#eff6ff', border: '#3b82f6', text: '#1e40af',
     borderStyle: 'solid', borderRadius: '12px', icon: 'D',
@@ -72,9 +62,12 @@ export function buildCrossDomainGraph(
     });
   }
 
-  // Cross-domain edges with descriptive labels and tooltips
+  // Edges with integration pattern labels
   for (const edge of crossDomainEdges) {
     const edgeId = `${edge.sourceDomain}--${edge.targetDomain}`;
+
+    // Thicker edges for stronger dependencies
+    const strokeWidth = Math.min(1 + Math.floor(edge.totalWeight / 5), 4);
 
     edges.push({
       id: edgeId,
@@ -82,6 +75,7 @@ export function buildCrossDomainGraph(
       target: edge.targetDomain,
       type: 'relationshipEdge',
       animated: true,
+      style: { strokeWidth },
       data: {
         relationship: 'cross-domain',
         label: buildEdgeLabel(edge),

--- a/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
+++ b/catalog-ui/src/components/graphs/utils/cross-domain-graph-data.ts
@@ -9,12 +9,12 @@ import { NODE_STYLES } from './colors';
 
 /**
  * Build edge label from integration patterns.
- * Shows icons + categories: "🔌 API (5)  ⚡ Events (3)"
+ * Shows categories with counts: "API (5) · Events (3)"
  */
 function buildEdgeLabel(edge: CrossDomainEdge): string {
   return edge.integrations
-    .map(i => `${i.icon} ${i.category} (${i.count})`)
-    .join('  ');
+    .map(i => `${i.category} (${i.count})`)
+    .join(' · ');
 }
 
 /**
@@ -22,7 +22,7 @@ function buildEdgeLabel(edge: CrossDomainEdge): string {
  */
 function buildEdgeTooltip(edge: CrossDomainEdge): string {
   const lines = edge.integrations.map(i =>
-    `${i.icon} ${i.category}: ${i.count} element-level dependencies`
+    `${i.category}: ${i.count} dependencies`
   );
   lines.push('');
   lines.push(`Total: ${edge.totalWeight} integration dependencies`);

--- a/catalog-ui/src/lib/cross-domain.ts
+++ b/catalog-ui/src/lib/cross-domain.ts
@@ -24,6 +24,11 @@ export interface CrossDomainEdge {
   totalWeight: number;
 }
 
+export interface IntegrationTarget {
+  id: string;
+  name: string;
+}
+
 export interface IntegrationPattern {
   /** Human-readable category: "API", "Events", "Data", "Service" */
   category: string;
@@ -31,6 +36,8 @@ export interface IntegrationPattern {
   count: number;
   /** Names of the target elements in this category */
   targetNames: string[];
+  /** Target elements with IDs for linking */
+  targets: IntegrationTarget[];
 }
 
 // ── Integration classification ──────────────────────────────
@@ -83,7 +90,7 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
   });
 
   // Aggregate cross-domain edges by domain pair + category
-  const edgeMap = new Map<string, Map<string, { category: string; count: number; names: Set<string> }>>();
+  const edgeMap = new Map<string, Map<string, { category: string; count: number; targets: Map<string, string> }>>();
 
   for (const edge of graph.edges) {
     // Skip structural relationships — not meaningful at cross-domain level
@@ -116,12 +123,12 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
     const existing = categories.get(classification.category);
     if (existing) {
       existing.count++;
-      existing.names.add(targetName);
+      existing.targets.set(edge.targetId, targetName);
     } else {
       categories.set(classification.category, {
         category: classification.category,
         count: 1,
-        names: new Set([targetName]),
+        targets: new Map([[edge.targetId, targetName]]),
       });
     }
   }
@@ -131,11 +138,17 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
   Array.from(edgeMap.entries()).forEach(([key, categories]) => {
     const [sourceDomain, targetDomain] = key.split('--');
     const integrations: IntegrationPattern[] = Array.from(categories.values())
-      .map(c => ({
-        category: c.category,
-        count: c.count,
-        targetNames: Array.from(c.names).sort(),
-      }))
+      .map(c => {
+        const targets = Array.from(c.targets.entries())
+          .map(([id, name]) => ({ id, name }))
+          .sort((a, b) => a.name.localeCompare(b.name));
+        return {
+          category: c.category,
+          count: c.count,
+          targetNames: targets.map(t => t.name),
+          targets,
+        };
+      })
       .sort((a, b) => b.count - a.count);
     const totalWeight = integrations.reduce((sum, i) => sum + i.count, 0);
 

--- a/catalog-ui/src/lib/cross-domain.ts
+++ b/catalog-ui/src/lib/cross-domain.ts
@@ -8,7 +8,8 @@ export interface CrossDomainEdge {
   sourceDomain: string;
   targetDomain: string;
   weight: number;
-  relationshipTypes: string[];
+  /** Relationship types with their counts, sorted by count desc */
+  typeCounts: { type: string; count: number }[];
 }
 
 /**
@@ -26,8 +27,8 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
     }
   });
 
-  // Aggregate cross-domain edges
-  const edgeMap = new Map<string, { weight: number; types: Set<string> }>();
+  // Aggregate cross-domain edges with per-type counts
+  const edgeMap = new Map<string, Map<string, number>>();
 
   for (const edge of graph.edges) {
     const sourceDomain = elementToDomain.get(edge.sourceId);
@@ -37,24 +38,28 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
     if (sourceDomain === targetDomain) continue;
 
     const key = `${sourceDomain}--${targetDomain}`;
-    const existing = edgeMap.get(key);
-    if (existing) {
-      existing.weight++;
-      existing.types.add(edge.relationshipType);
-    } else {
-      edgeMap.set(key, { weight: 1, types: new Set([edge.relationshipType]) });
+    let typeCounts = edgeMap.get(key);
+    if (!typeCounts) {
+      typeCounts = new Map<string, number>();
+      edgeMap.set(key, typeCounts);
     }
+    typeCounts.set(edge.relationshipType, (typeCounts.get(edge.relationshipType) || 0) + 1);
   }
 
-  // Convert to array, sorted by weight descending
+  // Convert to array, sorted by total weight descending
   const result: CrossDomainEdge[] = [];
-  Array.from(edgeMap.entries()).forEach(([key, value]) => {
+  Array.from(edgeMap.entries()).forEach(([key, typeCounts]) => {
     const [sourceDomain, targetDomain] = key.split('--');
+    const counts = Array.from(typeCounts.entries())
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count);
+    const weight = counts.reduce((sum, c) => sum + c.count, 0);
+
     result.push({
       sourceDomain,
       targetDomain,
-      weight: value.weight,
-      relationshipTypes: Array.from(value.types),
+      weight,
+      typeCounts: counts,
     });
   });
 

--- a/catalog-ui/src/lib/cross-domain.ts
+++ b/catalog-ui/src/lib/cross-domain.ts
@@ -1,21 +1,68 @@
 // catalog-ui/src/lib/cross-domain.ts
-// Derives domain-to-domain relationships from element-level edges.
+// Derives domain-to-domain integration dependencies from element-level edges.
 // Used by the Architecture Landscape page to show how domains interconnect.
+//
+// This is a MAP view (tier 2) — intentionally type-aware.
+// At the cross-domain level, architects care about integration patterns:
+//   - API dependencies (who calls whose APIs)
+//   - Event coupling (who consumes whose events)
+//   - Data dependencies (who accesses whose data)
+//   - Shared infrastructure (who shares tech components)
+//
+// Structural relationships (composition, aggregation) are filtered out
+// because they describe internal hierarchy, not cross-domain integration.
 
 import type { RegistryGraph } from './types';
 
+/** A meaningful integration dependency between two domains */
 export interface CrossDomainEdge {
   sourceDomain: string;
   targetDomain: string;
-  weight: number;
-  /** Relationship types with their counts, sorted by count desc */
-  typeCounts: { type: string; count: number }[];
+  /** Integration patterns found between these domains */
+  integrations: IntegrationPattern[];
+  /** Total element-level edges contributing to this domain link */
+  totalWeight: number;
 }
 
+export interface IntegrationPattern {
+  /** Human-readable category: "API", "Events", "Data", "Service" */
+  category: string;
+  /** Number of element-level edges in this category */
+  count: number;
+  /** Icon for the category */
+  icon: string;
+}
+
+// ── Integration classification ──────────────────────────────
+// Maps element types involved in cross-domain edges to meaningful categories.
+// Structural relationships (composition, aggregation) are excluded
+// because they don't represent cross-domain integration.
+
+const STRUCTURAL_RELATIONSHIP_TYPES = new Set([
+  'composition', 'aggregation',
+]);
+
+// Classify by the TARGET element type — "what is being depended on?"
+const TARGET_TYPE_TO_CATEGORY: Record<string, { category: string; icon: string }> = {
+  api_contract:    { category: 'API', icon: '🔌' },
+  api_endpoint:    { category: 'API', icon: '🔌' },
+  domain_event:    { category: 'Events', icon: '⚡' },
+  data_concept:    { category: 'Data', icon: '📊' },
+  data_aggregate:  { category: 'Data', icon: '📊' },
+  data_entity:     { category: 'Data', icon: '📊' },
+  software_system: { category: 'Service', icon: '⬡' },
+  software_subsystem: { category: 'Service', icon: '⬡' },
+  component:       { category: 'Service', icon: '⬡' },
+  infra_node:      { category: 'Infrastructure', icon: '🖥️' },
+  cloud_service:   { category: 'Infrastructure', icon: '☁️' },
+};
+
+const DEFAULT_CATEGORY = { category: 'Dependency', icon: '→' };
+
 /**
- * Walk all element-level edges and aggregate into domain-to-domain edges.
- * If element A (in domain X) has a relationship to element B (in domain Y),
- * that produces a domain-level edge X → Y with weight = number of such element edges.
+ * Derive meaningful cross-domain integration dependencies.
+ * Filters out internal structural relationships and categorizes
+ * the remaining edges by integration pattern.
  */
 export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] {
   // Build element ID → domain slug lookup
@@ -27,10 +74,13 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
     }
   });
 
-  // Aggregate cross-domain edges with per-type counts
-  const edgeMap = new Map<string, Map<string, number>>();
+  // Aggregate cross-domain edges by domain pair + category
+  const edgeMap = new Map<string, Map<string, { category: string; icon: string; count: number }>>();
 
   for (const edge of graph.edges) {
+    // Skip structural relationships — not meaningful at cross-domain level
+    if (STRUCTURAL_RELATIONSHIP_TYPES.has(edge.relationshipType)) continue;
+
     const sourceDomain = elementToDomain.get(edge.sourceId);
     const targetDomain = elementToDomain.get(edge.targetId);
 
@@ -38,30 +88,37 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
     if (sourceDomain === targetDomain) continue;
 
     const key = `${sourceDomain}--${targetDomain}`;
-    let typeCounts = edgeMap.get(key);
-    if (!typeCounts) {
-      typeCounts = new Map<string, number>();
-      edgeMap.set(key, typeCounts);
+    let categories = edgeMap.get(key);
+    if (!categories) {
+      categories = new Map();
+      edgeMap.set(key, categories);
     }
-    typeCounts.set(edge.relationshipType, (typeCounts.get(edge.relationshipType) || 0) + 1);
+
+    // Classify by target element type
+    const targetEl = graph.elements.get(edge.targetId);
+    const targetType = targetEl?.elementType || '';
+    const classification = TARGET_TYPE_TO_CATEGORY[targetType] || DEFAULT_CATEGORY;
+
+    const existing = categories.get(classification.category);
+    if (existing) {
+      existing.count++;
+    } else {
+      categories.set(classification.category, { ...classification, count: 1 });
+    }
   }
 
-  // Convert to array, sorted by total weight descending
+  // Convert to array
   const result: CrossDomainEdge[] = [];
-  Array.from(edgeMap.entries()).forEach(([key, typeCounts]) => {
+  Array.from(edgeMap.entries()).forEach(([key, categories]) => {
     const [sourceDomain, targetDomain] = key.split('--');
-    const counts = Array.from(typeCounts.entries())
-      .map(([type, count]) => ({ type, count }))
+    const integrations = Array.from(categories.values())
       .sort((a, b) => b.count - a.count);
-    const weight = counts.reduce((sum, c) => sum + c.count, 0);
+    const totalWeight = integrations.reduce((sum, i) => sum + i.count, 0);
 
-    result.push({
-      sourceDomain,
-      targetDomain,
-      weight,
-      typeCounts: counts,
-    });
+    if (totalWeight > 0) {
+      result.push({ sourceDomain, targetDomain, integrations, totalWeight });
+    }
   });
 
-  return result.sort((a, b) => b.weight - a.weight);
+  return result.sort((a, b) => b.totalWeight - a.totalWeight);
 }

--- a/catalog-ui/src/lib/cross-domain.ts
+++ b/catalog-ui/src/lib/cross-domain.ts
@@ -43,21 +43,29 @@ const STRUCTURAL_RELATIONSHIP_TYPES = new Set([
 ]);
 
 // Classify by the TARGET element type — "what is being depended on?"
+// Simplified to 3 categories architects actually think in:
+//   API Integration — calls to another domain's APIs
+//   Event Coupling  — consuming another domain's events
+//   Data Access     — depending on another domain's data
+// Everything else (services, components, infra, domains) maps to
+// "API Integration" because at the cross-domain level, if you depend
+// on another domain's service/component, you're going through its API.
 const TARGET_TYPE_TO_CATEGORY: Record<string, { category: string }> = {
-  api_contract:       { category: 'API' },
-  api_endpoint:       { category: 'API' },
-  domain_event:       { category: 'Events' },
-  data_concept:       { category: 'Data' },
-  data_aggregate:     { category: 'Data' },
-  data_entity:        { category: 'Data' },
-  software_system:    { category: 'Service' },
-  software_subsystem: { category: 'Service' },
-  component:          { category: 'Service' },
-  infra_node:         { category: 'Infrastructure' },
-  cloud_service:      { category: 'Infrastructure' },
+  api_contract:       { category: 'API Integration' },
+  api_endpoint:       { category: 'API Integration' },
+  software_system:    { category: 'API Integration' },
+  software_subsystem: { category: 'API Integration' },
+  component:          { category: 'API Integration' },
+  domain_event:       { category: 'Event Coupling' },
+  data_concept:       { category: 'Data Access' },
+  data_aggregate:     { category: 'Data Access' },
+  data_entity:        { category: 'Data Access' },
+  infra_node:         { category: 'Shared Infrastructure' },
+  cloud_service:      { category: 'Shared Infrastructure' },
 };
 
-const DEFAULT_CATEGORY = { category: 'Dependency' };
+// Domain-level references are not meaningful integration — skip them
+const SKIP_TARGET_TYPES = new Set(['domain']);
 
 /**
  * Derive meaningful cross-domain integration dependencies.
@@ -98,7 +106,12 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
     const targetEl = graph.elements.get(edge.targetId);
     const targetType = targetEl?.elementType || '';
     const targetName = (targetEl?.fields.name as string) || edge.targetId;
-    const classification = TARGET_TYPE_TO_CATEGORY[targetType] || DEFAULT_CATEGORY;
+
+    // Skip domain-level references — not meaningful integration
+    if (SKIP_TARGET_TYPES.has(targetType)) continue;
+
+    const classification = TARGET_TYPE_TO_CATEGORY[targetType];
+    if (!classification) continue; // Unknown types are not cross-domain integration
 
     const existing = categories.get(classification.category);
     if (existing) {

--- a/catalog-ui/src/lib/cross-domain.ts
+++ b/catalog-ui/src/lib/cross-domain.ts
@@ -29,6 +29,8 @@ export interface IntegrationPattern {
   category: string;
   /** Number of element-level edges in this category */
   count: number;
+  /** Names of the target elements in this category */
+  targetNames: string[];
 }
 
 // ── Integration classification ──────────────────────────────
@@ -73,7 +75,7 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
   });
 
   // Aggregate cross-domain edges by domain pair + category
-  const edgeMap = new Map<string, Map<string, { category: string; count: number }>>();
+  const edgeMap = new Map<string, Map<string, { category: string; count: number; names: Set<string> }>>();
 
   for (const edge of graph.edges) {
     // Skip structural relationships — not meaningful at cross-domain level
@@ -95,21 +97,32 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
     // Classify by target element type
     const targetEl = graph.elements.get(edge.targetId);
     const targetType = targetEl?.elementType || '';
+    const targetName = (targetEl?.fields.name as string) || edge.targetId;
     const classification = TARGET_TYPE_TO_CATEGORY[targetType] || DEFAULT_CATEGORY;
 
     const existing = categories.get(classification.category);
     if (existing) {
       existing.count++;
+      existing.names.add(targetName);
     } else {
-      categories.set(classification.category, { category: classification.category, count: 1 });
+      categories.set(classification.category, {
+        category: classification.category,
+        count: 1,
+        names: new Set([targetName]),
+      });
     }
   }
 
-  // Convert to array
+  // Convert to array with serializable types (no Set)
   const result: CrossDomainEdge[] = [];
   Array.from(edgeMap.entries()).forEach(([key, categories]) => {
     const [sourceDomain, targetDomain] = key.split('--');
-    const integrations = Array.from(categories.values())
+    const integrations: IntegrationPattern[] = Array.from(categories.values())
+      .map(c => ({
+        category: c.category,
+        count: c.count,
+        targetNames: Array.from(c.names).sort(),
+      }))
       .sort((a, b) => b.count - a.count);
     const totalWeight = integrations.reduce((sum, i) => sum + i.count, 0);
 

--- a/catalog-ui/src/lib/cross-domain.ts
+++ b/catalog-ui/src/lib/cross-domain.ts
@@ -1,0 +1,62 @@
+// catalog-ui/src/lib/cross-domain.ts
+// Derives domain-to-domain relationships from element-level edges.
+// Used by the Architecture Landscape page to show how domains interconnect.
+
+import type { RegistryGraph } from './types';
+
+export interface CrossDomainEdge {
+  sourceDomain: string;
+  targetDomain: string;
+  weight: number;
+  relationshipTypes: string[];
+}
+
+/**
+ * Walk all element-level edges and aggregate into domain-to-domain edges.
+ * If element A (in domain X) has a relationship to element B (in domain Y),
+ * that produces a domain-level edge X → Y with weight = number of such element edges.
+ */
+export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] {
+  // Build element ID → domain slug lookup
+  const elementToDomain = new Map<string, string>();
+  Array.from(graph.indexes.byDomain.entries()).forEach(([domainSlug, elements]) => {
+    if (domainSlug === 'unknown') return;
+    for (const el of elements) {
+      elementToDomain.set(el.id, domainSlug);
+    }
+  });
+
+  // Aggregate cross-domain edges
+  const edgeMap = new Map<string, { weight: number; types: Set<string> }>();
+
+  for (const edge of graph.edges) {
+    const sourceDomain = elementToDomain.get(edge.sourceId);
+    const targetDomain = elementToDomain.get(edge.targetId);
+
+    if (!sourceDomain || !targetDomain) continue;
+    if (sourceDomain === targetDomain) continue;
+
+    const key = `${sourceDomain}--${targetDomain}`;
+    const existing = edgeMap.get(key);
+    if (existing) {
+      existing.weight++;
+      existing.types.add(edge.relationshipType);
+    } else {
+      edgeMap.set(key, { weight: 1, types: new Set([edge.relationshipType]) });
+    }
+  }
+
+  // Convert to array, sorted by weight descending
+  const result: CrossDomainEdge[] = [];
+  Array.from(edgeMap.entries()).forEach(([key, value]) => {
+    const [sourceDomain, targetDomain] = key.split('--');
+    result.push({
+      sourceDomain,
+      targetDomain,
+      weight: value.weight,
+      relationshipTypes: Array.from(value.types),
+    });
+  });
+
+  return result.sort((a, b) => b.weight - a.weight);
+}

--- a/catalog-ui/src/lib/cross-domain.ts
+++ b/catalog-ui/src/lib/cross-domain.ts
@@ -29,8 +29,6 @@ export interface IntegrationPattern {
   category: string;
   /** Number of element-level edges in this category */
   count: number;
-  /** Icon for the category */
-  icon: string;
 }
 
 // ── Integration classification ──────────────────────────────
@@ -43,21 +41,21 @@ const STRUCTURAL_RELATIONSHIP_TYPES = new Set([
 ]);
 
 // Classify by the TARGET element type — "what is being depended on?"
-const TARGET_TYPE_TO_CATEGORY: Record<string, { category: string; icon: string }> = {
-  api_contract:    { category: 'API', icon: '🔌' },
-  api_endpoint:    { category: 'API', icon: '🔌' },
-  domain_event:    { category: 'Events', icon: '⚡' },
-  data_concept:    { category: 'Data', icon: '📊' },
-  data_aggregate:  { category: 'Data', icon: '📊' },
-  data_entity:     { category: 'Data', icon: '📊' },
-  software_system: { category: 'Service', icon: '⬡' },
-  software_subsystem: { category: 'Service', icon: '⬡' },
-  component:       { category: 'Service', icon: '⬡' },
-  infra_node:      { category: 'Infrastructure', icon: '🖥️' },
-  cloud_service:   { category: 'Infrastructure', icon: '☁️' },
+const TARGET_TYPE_TO_CATEGORY: Record<string, { category: string }> = {
+  api_contract:       { category: 'API' },
+  api_endpoint:       { category: 'API' },
+  domain_event:       { category: 'Events' },
+  data_concept:       { category: 'Data' },
+  data_aggregate:     { category: 'Data' },
+  data_entity:        { category: 'Data' },
+  software_system:    { category: 'Service' },
+  software_subsystem: { category: 'Service' },
+  component:          { category: 'Service' },
+  infra_node:         { category: 'Infrastructure' },
+  cloud_service:      { category: 'Infrastructure' },
 };
 
-const DEFAULT_CATEGORY = { category: 'Dependency', icon: '→' };
+const DEFAULT_CATEGORY = { category: 'Dependency' };
 
 /**
  * Derive meaningful cross-domain integration dependencies.
@@ -75,7 +73,7 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
   });
 
   // Aggregate cross-domain edges by domain pair + category
-  const edgeMap = new Map<string, Map<string, { category: string; icon: string; count: number }>>();
+  const edgeMap = new Map<string, Map<string, { category: string; count: number }>>();
 
   for (const edge of graph.edges) {
     // Skip structural relationships — not meaningful at cross-domain level
@@ -103,7 +101,7 @@ export function deriveCrossDomainEdges(graph: RegistryGraph): CrossDomainEdge[] 
     if (existing) {
       existing.count++;
     } else {
-      categories.set(classification.category, { ...classification, count: 1 });
+      categories.set(classification.category, { category: classification.category, count: 1 });
     }
   }
 

--- a/catalog-ui/src/pages/maps/index.astro
+++ b/catalog-ui/src/pages/maps/index.astro
@@ -12,6 +12,19 @@ import { domains, eventMappingEnabled, heatmapMappingEnabled } from '../../data/
   </div>
 
   <div class="page-body">
+    <!-- Cross-domain landscape link -->
+    <a href="/maps/landscape" class="card" style="display: block; padding: 20px; border-top: 3px solid #6366f1; margin-bottom: 16px; text-decoration: none; color: inherit; transition: border-color 0.15s;">
+      <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 8px;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#6366f1" stroke-width="2">
+          <circle cx="12" cy="12" r="10"/>
+          <line x1="2" y1="12" x2="22" y2="12"/>
+          <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+        </svg>
+        <h3 style="font-size: 15px; font-weight: 600; margin: 0; color: rgb(var(--ec-page-text));">Architecture Landscape</h3>
+      </div>
+      <p style="font-size: 13px; color: rgb(var(--ec-page-text-muted)); margin: 0;">Cross-domain view showing how all domains relate to each other at the highest level</p>
+    </a>
+
     <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px;">
       {domains.map(d => (
         <div class="card" style={`padding: 20px; border-top: 3px solid ${d.color};`}>

--- a/catalog-ui/src/pages/maps/landscape.astro
+++ b/catalog-ui/src/pages/maps/landscape.astro
@@ -46,7 +46,7 @@ const domainPairs = crossDomainEdges.length;
     </div>
 
     <div class="landscape-footer">
-      <p>Click any domain to drill into its context map. Edges show integration patterns (API, Events, Data, Service). Hover edge labels for details. Structural relationships (composition, aggregation) are excluded.</p>
+      <p>Toggle domains in the selector to focus on specific integrations. Click a domain to drill into its context map. Hover edge labels for integration details.</p>
     </div>
   </div>
 </Layout>

--- a/catalog-ui/src/pages/maps/landscape.astro
+++ b/catalog-ui/src/pages/maps/landscape.astro
@@ -4,9 +4,10 @@ import { domains, graph } from '../../data/registry';
 import { deriveCrossDomainEdges } from '../../lib/cross-domain';
 import CrossDomainMap from '../../components/graphs/CrossDomainMap';
 
-// Derive cross-domain edges at build time
+// Derive cross-domain integration dependencies at build time
 const crossDomainEdges = graph ? deriveCrossDomainEdges(graph) : [];
-const totalCrossDomainRels = crossDomainEdges.reduce((sum, e) => sum + e.weight, 0);
+const totalIntegrations = crossDomainEdges.reduce((sum, e) => sum + e.totalWeight, 0);
+const domainPairs = crossDomainEdges.length;
 ---
 
 <Layout title="Architecture Landscape">
@@ -30,7 +31,9 @@ const totalCrossDomainRels = crossDomainEdges.reduce((sum, e) => sum + e.weight,
       <div class="landscape-header-right">
         <span class="landscape-stat">{domains.length} domains</span>
         <span class="landscape-stat-sep">&middot;</span>
-        <span class="landscape-stat">{totalCrossDomainRels} cross-domain relationships</span>
+        <span class="landscape-stat">{domainPairs} domain connections</span>
+        <span class="landscape-stat-sep">&middot;</span>
+        <span class="landscape-stat">{totalIntegrations} integration dependencies</span>
       </div>
     </div>
 
@@ -43,7 +46,7 @@ const totalCrossDomainRels = crossDomainEdges.reduce((sum, e) => sum + e.weight,
     </div>
 
     <div class="landscape-footer">
-      <p>Click any domain to drill into its context map. Edge labels show the number of element-level relationships between domains.</p>
+      <p>Click any domain to drill into its context map. Edges show integration patterns (API, Events, Data, Service). Hover edge labels for details. Structural relationships (composition, aggregation) are excluded.</p>
     </div>
   </div>
 </Layout>

--- a/catalog-ui/src/pages/maps/landscape.astro
+++ b/catalog-ui/src/pages/maps/landscape.astro
@@ -1,0 +1,146 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { domains, graph } from '../../data/registry';
+import { deriveCrossDomainEdges } from '../../lib/cross-domain';
+import CrossDomainMap from '../../components/graphs/CrossDomainMap';
+
+// Derive cross-domain edges at build time
+const crossDomainEdges = graph ? deriveCrossDomainEdges(graph) : [];
+const totalCrossDomainRels = crossDomainEdges.reduce((sum, e) => sum + e.weight, 0);
+---
+
+<Layout title="Architecture Landscape">
+  <div class="landscape-fullpage">
+    <div class="landscape-header">
+      <div class="landscape-header-left">
+        <a href="/maps" class="landscape-back">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+          Back to Maps
+        </a>
+        <div class="landscape-title">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="2" y1="12" x2="22" y2="12"/>
+            <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+          </svg>
+          <h1>Architecture Landscape</h1>
+          <span class="badge badge-sm badge-domain">Cross-Domain</span>
+        </div>
+      </div>
+      <div class="landscape-header-right">
+        <span class="landscape-stat">{domains.length} domains</span>
+        <span class="landscape-stat-sep">&middot;</span>
+        <span class="landscape-stat">{totalCrossDomainRels} cross-domain relationships</span>
+      </div>
+    </div>
+
+    <div class="landscape-container">
+      <CrossDomainMap
+        client:only="react"
+        domains={domains}
+        crossDomainEdges={crossDomainEdges}
+      />
+    </div>
+
+    <div class="landscape-footer">
+      <p>Click any domain to drill into its context map. Edge labels show the number of element-level relationships between domains.</p>
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .landscape-fullpage {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 20px);
+    background: rgb(var(--ec-page-bg));
+    overflow: hidden;
+  }
+
+  .landscape-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 24px;
+    border-bottom: 1px solid rgb(var(--ec-page-border));
+    background: rgb(var(--ec-page-surface));
+    flex-shrink: 0;
+  }
+
+  .landscape-header-left {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .landscape-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: rgb(var(--ec-page-text-muted));
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .landscape-back:hover {
+    color: rgb(59, 130, 246);
+  }
+
+  .landscape-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: rgb(var(--ec-page-text));
+  }
+
+  .landscape-title h1 {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0;
+    color: rgb(var(--ec-page-text));
+  }
+
+  .landscape-header-right {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .landscape-stat {
+    font-size: 12px;
+    color: rgb(var(--ec-page-text-muted));
+  }
+
+  .landscape-stat-sep {
+    color: rgb(var(--ec-page-text-muted));
+    opacity: 0.4;
+  }
+
+  .landscape-container {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .landscape-container > div {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .landscape-footer {
+    padding: 8px 24px;
+    border-top: 1px solid rgb(var(--ec-page-border));
+    background: rgb(var(--ec-page-surface));
+    flex-shrink: 0;
+  }
+
+  .landscape-footer p {
+    font-size: 12px;
+    color: rgb(var(--ec-page-text-muted));
+    margin: 0;
+    text-align: center;
+  }
+</style>

--- a/catalog-ui/src/styles/global.css
+++ b/catalog-ui/src/styles/global.css
@@ -303,6 +303,132 @@
   background: rgb(51 65 85);
 }
 
+/* ── Landscape domain selector chips ── */
+.landscape-domain-selector {
+  max-width: 400px;
+}
+.landscape-domain-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  border: 2px solid #e2e8f0;
+  border-radius: 0;
+  background: white;
+  color: #64748b;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  font-family: 'JetBrains Mono', monospace;
+}
+.landscape-domain-chip:hover {
+  border-color: var(--chip-color, #94a3b8);
+  color: #334155;
+}
+.landscape-domain-chip--active {
+  border-color: var(--chip-color, #3b82f6);
+  background: color-mix(in srgb, var(--chip-color, #3b82f6) 10%, white);
+  color: #1e293b;
+  font-weight: 600;
+}
+.landscape-domain-chip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 0;
+  flex-shrink: 0;
+}
+
+[data-theme="dark"] .landscape-domain-chip {
+  border-color: #334155;
+  background: rgb(15 23 42);
+  color: #94a3b8;
+}
+[data-theme="dark"] .landscape-domain-chip:hover {
+  border-color: var(--chip-color, #64748b);
+  color: #e2e8f0;
+}
+[data-theme="dark"] .landscape-domain-chip--active {
+  border-color: var(--chip-color, #3b82f6);
+  background: color-mix(in srgb, var(--chip-color, #3b82f6) 15%, rgb(15 23 42));
+  color: #e2e8f0;
+}
+
+/* ── Edge tooltip (styled popup) ── */
+.edge-tooltip {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #0f172a;
+  border: 2px solid #334155;
+  border-radius: 0;
+  padding: 10px 14px;
+  min-width: 200px;
+  max-width: 300px;
+  z-index: 1000;
+  font-family: 'JetBrains Mono', monospace;
+  pointer-events: auto;
+}
+.edge-tooltip::before {
+  content: '';
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 10px;
+  height: 10px;
+  background: #0f172a;
+  border-top: 2px solid #334155;
+  border-left: 2px solid #334155;
+}
+.edge-tooltip-section {
+  margin-bottom: 8px;
+}
+.edge-tooltip-section:last-child {
+  margin-bottom: 0;
+}
+.edge-tooltip-category {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #94a3b8;
+  margin-bottom: 4px;
+  padding-bottom: 3px;
+  border-bottom: 1px solid #1e293b;
+}
+.edge-tooltip-item {
+  font-size: 11px;
+  color: #e2e8f0;
+  padding: 2px 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.edge-tooltip-arrow {
+  color: #475569;
+  font-size: 10px;
+  flex-shrink: 0;
+}
+.edge-tooltip-link {
+  color: #e2e8f0;
+  text-decoration: none;
+  border-bottom: 1px solid #475569;
+  transition: color 0.15s, border-color 0.15s;
+}
+.edge-tooltip-link:hover {
+  color: #60a5fa;
+  border-color: #60a5fa;
+}
+
+/* Light theme tooltip overrides */
+[data-theme="light"] .edge-tooltip,
+:root:not([data-theme="dark"]) .edge-tooltip {
+  background: #0f172a;
+  border-color: #334155;
+}
+
 /* ── Reset ── */
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 


### PR DESCRIPTION
## Summary
- New `/maps/landscape` page showing domains as nodes and inter-domain relationships as weighted edges
- Derives domain-to-domain connections by aggregating element-level edges across domain boundaries
- Reuses existing ReactFlow + dagre + BaseNode + RelationshipEdge infrastructure
- Maps index updated with prominent landscape link at top

**Source:** Reddit feedback — "How do you show high-level diagrams with fewer details across many applications?"

Closes #57

## New files
- `src/lib/cross-domain.ts` — data derivation layer
- `src/components/graphs/CrossDomainMap.tsx` — React component
- `src/components/graphs/utils/cross-domain-graph-data.ts` — graph builder
- `src/pages/maps/landscape.astro` — Astro page

## Test plan
- [x] Build passes (287 pages)
- [x] Dev server renders `/maps/landscape` correctly
- [ ] Manual: verify domain nodes display with correct colors
- [ ] Manual: verify edge labels show relationship counts
- [ ] Manual: click domain node navigates to context map
- [ ] Manual: PNG export works

🤖 Generated with [Claude Code](https://claude.com/claude-code)