### PR TITLE
feat: visual differentiation for planned, deprecated, and external elements

### DIFF
--- a/catalog-ui/src/components/graphs/DomainContextMap.tsx
+++ b/catalog-ui/src/components/graphs/DomainContextMap.tsx
@@ -21,6 +21,7 @@ import '@xyflow/react/dist/style.css';
 import BaseNode from './nodes/BaseNode';
 import RelationshipEdge, { EdgeMarkerDefs } from './edges/RelationshipEdge';
 import FocusModeModal from './FocusModeModal';
+import GraphLegend from './GraphLegend';
 import { applyDagreLayout } from './utils/layout';
 import { buildDomainGraph } from './utils/graph-data';
 import { NODE_STYLES, EDGE_STYLES, getNodeStyle } from './utils/colors';
@@ -367,6 +368,11 @@ function DomainContextMapInner({ domain, elements }: DomainContextMapProps) {
                 </>
               )}
             </div>
+          </Panel>
+
+          {/* Status / Sourcing Legend */}
+          <Panel position="bottom-left">
+            <GraphLegend />
           </Panel>
         </ReactFlow>
       </div>

--- a/catalog-ui/src/components/graphs/ElementContextGraph.tsx
+++ b/catalog-ui/src/components/graphs/ElementContextGraph.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useState, useEffect } from 'react';
 import {
   ReactFlow,
   Background,
+  Panel,
   useNodesState,
   useEdgesState,
   useReactFlow,
@@ -17,6 +18,7 @@ import '@xyflow/react/dist/style.css';
 
 import BaseNode from './nodes/BaseNode';
 import RelationshipEdge, { EdgeMarkerDefs } from './edges/RelationshipEdge';
+import GraphLegend from './GraphLegend';
 import { applyDagreLayout } from './utils/layout';
 import { buildElementGraph } from './utils/graph-data';
 import type { Element } from '../../data/registry';
@@ -145,6 +147,9 @@ function ElementContextGraphInner({ element, allElements, height = 350 }: Elemen
         zoomOnScroll
       >
         <Background color="#e2e8f0" gap={16} size={1} />
+        <Panel position="bottom-left">
+          <GraphLegend />
+        </Panel>
       </ReactFlow>
     </div>
   );

--- a/catalog-ui/src/components/graphs/EventFlowGraph.tsx
+++ b/catalog-ui/src/components/graphs/EventFlowGraph.tsx
@@ -26,6 +26,7 @@ import '@xyflow/react/dist/style.css';
 import BaseNode from './nodes/BaseNode';
 import { EdgeMarkerDefs } from './edges/RelationshipEdge';
 import FocusModeModal from './FocusModeModal';
+import GraphLegend from './GraphLegend';
 import { applyDagreLayout } from './utils/layout';
 import { buildEventFlowGraph } from './utils/event-graph-data';
 import type { EventFlow } from '../../data/registry';
@@ -310,6 +311,11 @@ function EventFlowGraphInner({ eventFlow, domainName }: EventFlowGraphProps) {
               </div>
             </div>
           </div>
+        </Panel>
+
+        {/* Status / Sourcing Legend */}
+        <Panel position="bottom-left">
+          <GraphLegend />
         </Panel>
       </ReactFlow>
       </div>

--- a/catalog-ui/src/components/graphs/GraphLegend.tsx
+++ b/catalog-ui/src/components/graphs/GraphLegend.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+
+export interface GraphLegendProps {
+  defaultOpen?: boolean;
+}
+
+export default function GraphLegend({ defaultOpen = false }: GraphLegendProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div
+      style={{
+        background: 'var(--legend-bg, rgba(255,255,255,0.96))',
+        border: '1px solid var(--legend-border, #e2e8f0)',
+        borderRadius: 8,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 12,
+        color: 'var(--legend-text, #334155)',
+        overflow: 'hidden',
+        maxWidth: 220,
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-label={open ? 'Collapse legend' : 'Expand legend'}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+          padding: '8px 12px',
+          background: 'transparent',
+          border: 'none',
+          color: 'inherit',
+          font: 'inherit',
+          cursor: 'pointer',
+          fontWeight: 600,
+        }}
+      >
+        <span>Legend</span>
+        <span aria-hidden="true" style={{ fontSize: 10, opacity: 0.7 }}>
+          {open ? '▾' : '▸'}
+        </span>
+      </button>
+
+      {open && (
+        <div style={{ padding: '4px 12px 12px', display: 'grid', gap: 10 }}>
+          <LegendRow swatch={<Swatch borderStyle="solid" />} label="Active" />
+          <LegendRow swatch={<Swatch borderStyle="dashed" />} label="Planned (draft)" />
+          <LegendRow swatch={<Swatch borderStyle="solid" muted />} label="Deprecated" />
+          <LegendRow swatch={<CloudSwatch />} label="External / SaaS" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LegendRow({ swatch, label }: { swatch: React.ReactNode; label: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      {swatch}
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function Swatch({ borderStyle, muted = false }: { borderStyle: 'solid' | 'dashed'; muted?: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: 'inline-block',
+        width: 20,
+        height: 14,
+        border: `2px ${borderStyle} ${muted ? '#94a3b8' : '#64748b'}`,
+        borderRadius: 3,
+        background: 'var(--legend-swatch-bg, #f8fafc)',
+        opacity: muted ? 0.55 : 1,
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function CloudSwatch() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 20,
+        height: 14,
+        border: '1px solid #64748b',
+        borderRadius: 3,
+        color: '#64748b',
+        flexShrink: 0,
+      }}
+    >
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M18 10h-1.26A8 8 0 109 20h9a5 5 0 000-10z" />
+      </svg>
+    </span>
+  );
+}

--- a/catalog-ui/src/components/graphs/nodes/BaseNode.tsx
+++ b/catalog-ui/src/components/graphs/nodes/BaseNode.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import type { NodeStyle } from '../utils/colors';
+import { getStatusVisuals } from '../utils/status-visuals';
 
 export interface BaseNodeData {
   label: string;
@@ -145,6 +146,13 @@ export default function BaseNode({ data, id }: NodeProps) {
   );
   const [hovered, setHovered] = React.useState(false);
 
+  const visuals = getStatusVisuals(d.status, d.sourcing);
+  const baseOpacity = d.opacity ?? 1;
+  const effectiveOpacity = baseOpacity * visuals.opacity;
+  const borderColor = visuals.muted
+    ? 'var(--node-muted-border, #94a3b8)'
+    : style?.border || '#e2e8f0';
+
   const defaultShadow = '0 1px 4px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)';
   const hoverShadow = `0 4px 12px rgba(0,0,0,0.10), 0 2px 6px rgba(0,0,0,0.06)`;
   const focusShadow = `0 0 0 3px ${style?.border}40, 0 4px 12px rgba(0,0,0,0.12)`;
@@ -156,7 +164,7 @@ export default function BaseNode({ data, id }: NodeProps) {
       onMouseLeave={() => setHovered(false)}
       style={{
         background: 'var(--node-bg, white)',
-        border: `2px solid ${style?.border || '#e2e8f0'}`,
+        border: `2px ${visuals.borderStyle} ${borderColor}`,
         borderRadius: '8px',
         minWidth: 200,
         maxWidth: 280,
@@ -166,7 +174,7 @@ export default function BaseNode({ data, id }: NodeProps) {
         transform: hovered && !isFocused ? 'translateY(-1px)' : 'none',
         boxShadow: isFocused ? focusShadow : hovered ? hoverShadow : defaultShadow,
         position: 'relative',
-        opacity: d.opacity ?? 1,
+        opacity: effectiveOpacity,
         overflow: 'hidden',
       }}
     >
@@ -335,6 +343,33 @@ export default function BaseNode({ data, id }: NodeProps) {
             background: style?.border || '#3b82f6',
           }}
         />
+      )}
+
+      {/* External/SaaS cloud indicator (top-right overlay) */}
+      {visuals.showExternalIndicator && (
+        <div
+          title={`External / ${d.sourcing}`}
+          aria-label={`External sourcing: ${d.sourcing}`}
+          style={{
+            position: 'absolute',
+            top: 6,
+            right: 6,
+            width: 20,
+            height: 20,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: 4,
+            background: 'var(--node-bg, white)',
+            border: `1px solid ${style?.border || '#94a3b8'}`,
+            color: style?.border || '#64748b',
+            pointerEvents: 'auto',
+          }}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 10h-1.26A8 8 0 109 20h9a5 5 0 000-10z" />
+          </svg>
+        </div>
       )}
     </div>
   );

--- a/catalog-ui/src/components/graphs/utils/__tests__/status-visuals.test.ts
+++ b/catalog-ui/src/components/graphs/utils/__tests__/status-visuals.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { getStatusVisuals } from '../status-visuals';
+
+describe('getStatusVisuals', () => {
+  describe('borderStyle', () => {
+    it('solid for active status', () => {
+      expect(getStatusVisuals('active').borderStyle).toBe('solid');
+    });
+
+    it('dashed for draft status', () => {
+      expect(getStatusVisuals('draft').borderStyle).toBe('dashed');
+    });
+
+    it('dashed for planned status (alt vocab)', () => {
+      expect(getStatusVisuals('planned').borderStyle).toBe('dashed');
+    });
+
+    it('dashed for proposed status (alt vocab)', () => {
+      expect(getStatusVisuals('proposed').borderStyle).toBe('dashed');
+    });
+
+    it('solid for unknown or missing status', () => {
+      expect(getStatusVisuals().borderStyle).toBe('solid');
+      expect(getStatusVisuals('').borderStyle).toBe('solid');
+      expect(getStatusVisuals('something-custom').borderStyle).toBe('solid');
+    });
+
+    it('is case-insensitive', () => {
+      expect(getStatusVisuals('DRAFT').borderStyle).toBe('dashed');
+      expect(getStatusVisuals(' Draft ').borderStyle).toBe('dashed');
+    });
+  });
+
+  describe('opacity', () => {
+    it('1 for active', () => {
+      expect(getStatusVisuals('active').opacity).toBe(1);
+    });
+
+    it('0.55 for deprecated', () => {
+      expect(getStatusVisuals('deprecated').opacity).toBe(0.55);
+    });
+
+    it('0.55 for retired (alt vocab)', () => {
+      expect(getStatusVisuals('retired').opacity).toBe(0.55);
+    });
+
+    it('1 for draft (not faded — planned is its own treatment)', () => {
+      expect(getStatusVisuals('draft').opacity).toBe(1);
+    });
+  });
+
+  describe('muted', () => {
+    it('true only for deprecated-class statuses', () => {
+      expect(getStatusVisuals('deprecated').muted).toBe(true);
+      expect(getStatusVisuals('retired').muted).toBe(true);
+      expect(getStatusVisuals('archived').muted).toBe(true);
+      expect(getStatusVisuals('draft').muted).toBe(false);
+      expect(getStatusVisuals('active').muted).toBe(false);
+    });
+  });
+
+  describe('showExternalIndicator', () => {
+    it('false for in-house sourcing', () => {
+      expect(getStatusVisuals('active', 'in-house').showExternalIndicator).toBe(false);
+    });
+
+    it('true for vendor sourcing', () => {
+      expect(getStatusVisuals('active', 'vendor').showExternalIndicator).toBe(true);
+    });
+
+    it('true for hybrid sourcing', () => {
+      expect(getStatusVisuals('active', 'hybrid').showExternalIndicator).toBe(true);
+    });
+
+    it('true for saas / buy / external (alt vocab)', () => {
+      expect(getStatusVisuals('active', 'saas').showExternalIndicator).toBe(true);
+      expect(getStatusVisuals('active', 'buy').showExternalIndicator).toBe(true);
+      expect(getStatusVisuals('active', 'external').showExternalIndicator).toBe(true);
+    });
+
+    it('false when sourcing is missing', () => {
+      expect(getStatusVisuals('active').showExternalIndicator).toBe(false);
+      expect(getStatusVisuals('active', '').showExternalIndicator).toBe(false);
+    });
+  });
+
+  describe('combined scenarios', () => {
+    it('deprecated external: faded + solid border + cloud', () => {
+      const v = getStatusVisuals('deprecated', 'vendor');
+      expect(v.borderStyle).toBe('solid');
+      expect(v.opacity).toBe(0.55);
+      expect(v.showExternalIndicator).toBe(true);
+      expect(v.muted).toBe(true);
+    });
+
+    it('planned external: dashed + full opacity + cloud', () => {
+      const v = getStatusVisuals('draft', 'vendor');
+      expect(v.borderStyle).toBe('dashed');
+      expect(v.opacity).toBe(1);
+      expect(v.showExternalIndicator).toBe(true);
+      expect(v.muted).toBe(false);
+    });
+  });
+});

--- a/catalog-ui/src/components/graphs/utils/event-graph-data.ts
+++ b/catalog-ui/src/components/graphs/utils/event-graph-data.ts
@@ -50,6 +50,7 @@ export function buildEventFlowGraph(
         elementType: eventFlow.serviceLabel,
         catalogUrl: `/catalog/${svc.id}`,
         status: svc.status,
+        sourcing: svc.sourcing,
         mappingIcon: NODE_STYLES['software_subsystem']?.icon ?? 'Sub',
         style: svc.isCrossDomain
           ? { ...style, borderStyle: 'dashed' }
@@ -74,6 +75,7 @@ export function buildEventFlowGraph(
         elementType: eventFlow.eventLabel,
         catalogUrl: `/catalog/${evt.id}`,
         status: evt.status,
+        sourcing: evt.sourcing,
         mappingIcon: NODE_STYLES['domain_event']?.icon ?? 'Ev',
         style,
         rank: 1,

--- a/catalog-ui/src/components/graphs/utils/status-visuals.ts
+++ b/catalog-ui/src/components/graphs/utils/status-visuals.ts
@@ -1,0 +1,36 @@
+// catalog-ui/src/components/graphs/utils/status-visuals.ts
+// Maps registry frontmatter `status` and `sourcing` values to visual treatment.
+// Values come from the registry schema (see registry-v2/**/_template.md),
+// not from element type names — so this does not violate the vocab-agnostic rule.
+
+export interface StatusVisuals {
+  borderStyle: 'solid' | 'dashed' | 'dotted';
+  opacity: number;
+  showExternalIndicator: boolean;
+  muted: boolean;
+}
+
+// Planned work — visualised with a dashed border
+const PLANNED_STATUSES = new Set(['draft', 'planned', 'proposed']);
+
+// Retired work — visualised as faded
+const DEPRECATED_STATUSES = new Set(['deprecated', 'retired', 'archived']);
+
+// Non-owned sourcing — visualised with a cloud indicator
+const EXTERNAL_SOURCINGS = new Set(['vendor', 'saas', 'hybrid', 'buy', 'external']);
+
+export function getStatusVisuals(status?: string, sourcing?: string): StatusVisuals {
+  const s = (status || '').toLowerCase().trim();
+  const src = (sourcing || '').toLowerCase().trim();
+
+  const isPlanned = PLANNED_STATUSES.has(s);
+  const isDeprecated = DEPRECATED_STATUSES.has(s);
+  const isExternal = EXTERNAL_SOURCINGS.has(src);
+
+  return {
+    borderStyle: isPlanned ? 'dashed' : 'solid',
+    opacity: isDeprecated ? 0.55 : 1,
+    showExternalIndicator: isExternal,
+    muted: isDeprecated,
+  };
+}

--- a/catalog-ui/src/lib/event-mapping-loader.ts
+++ b/catalog-ui/src/lib/event-mapping-loader.ts
@@ -38,6 +38,7 @@ export interface EventNode {
   name: string;
   description: string;
   status: string;
+  sourcing?: string;
   format: string;
   domain: string;
 }
@@ -46,6 +47,7 @@ export interface ServiceNode {
   id: string;
   name: string;
   status: string;
+  sourcing?: string;
   domain: string;
   isCrossDomain: boolean;
 }
@@ -196,6 +198,7 @@ export function resolveEventFlows(
       name: (event.fields.name as string) ?? event.id,
       description: (event.fields.description as string) ?? '',
       status: (event.fields.status as string) ?? 'active',
+      sourcing: event.fields.sourcing as string | undefined,
       format: (event.fields.event_format as string) ?? '',
       domain: domainId,
     };
@@ -296,6 +299,7 @@ function addServiceNode(
     id: element.id,
     name: (element.fields.name as string) ?? element.id,
     status: (element.fields.status as string) ?? 'active',
+    sourcing: element.fields.sourcing as string | undefined,
     domain: normalizedDomain,
     isCrossDomain: normalizedDomain !== domainId,
   });


### PR DESCRIPTION
## Summary

Addresses Reddit feedback: *"how do you show planned/future-state architecture?"* and *"how do you show SaaS / external / black-boxed applications?"*

Graph nodes now encode element `status` and `sourcing` visually so you can tell the monolith from its planned replacement, and an in-house service from a vendor SaaS — at a glance.

### Visual rules

| Frontmatter | Visual | Meaning |
|---|---|---|
| `status: draft \| planned \| proposed` | Dashed border | Planned / not built yet |
| `status: deprecated \| retired \| archived` | Faded + muted border | Being retired |
| `sourcing: vendor \| saas \| hybrid \| buy \| external` | Cloud icon (top-right overlay) | Not our code |

Active + in-house nodes are unchanged.

### Where it shows up

- Domain context maps
- Element context graphs (element detail pages)
- Event flow graphs
- Collapsible `GraphLegend` (bottom-left) explains the visual language

### How to verify

- `/domains/integration-and-connectivity/` — cloud icons on Kong, Integration Middleware, etc.
- `/catalog/api_endpoint--notification-api/` — dashed border (it's `status: draft`)
- Click "Legend ▸" in any graph to see the swatches

### Vocab-agnostic

Styling is driven by schema-defined frontmatter values (`status`, `sourcing`), not element type names. Unknown status/sourcing values fall back to solid border, full opacity, no cloud icon.

## Test plan

- [x] 18 new unit tests for `getStatusVisuals()` (all combinations of status + sourcing)
- [x] All 99 existing tests still pass
- [x] Astro build clean — 287 pages built
- [x] Visually verified on dev server across domain maps, event flow, and element pages

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)