### PR TITLE
fix: graph node key respects dark mode and uses clearer label

### DIFF
--- a/catalog-ui/src/components/graphs/GraphLegend.tsx
+++ b/catalog-ui/src/components/graphs/GraphLegend.tsx
@@ -2,21 +2,21 @@ import React, { useState } from 'react';
 
 export interface GraphLegendProps {
   defaultOpen?: boolean;
+  title?: string;
 }
 
-export default function GraphLegend({ defaultOpen = false }: GraphLegendProps) {
+export default function GraphLegend({
+  defaultOpen = false,
+  title = 'Node key',
+}: GraphLegendProps) {
   const [open, setOpen] = useState(defaultOpen);
 
   return (
     <div
+      className="graph-panel-box"
       style={{
-        background: 'var(--legend-bg, rgba(255,255,255,0.96))',
-        border: '1px solid var(--legend-border, #e2e8f0)',
-        borderRadius: 8,
-        boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
         fontFamily: 'Inter, system-ui, sans-serif',
         fontSize: 12,
-        color: 'var(--legend-text, #334155)',
         overflow: 'hidden',
         maxWidth: 220,
       }}
@@ -25,22 +25,23 @@ export default function GraphLegend({ defaultOpen = false }: GraphLegendProps) {
         type="button"
         onClick={() => setOpen(!open)}
         aria-expanded={open}
-        aria-label={open ? 'Collapse legend' : 'Expand legend'}
+        aria-label={open ? `Collapse ${title}` : `Expand ${title}`}
+        className="graph-panel-heading"
         style={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
           width: '100%',
           padding: '8px 12px',
+          margin: 0,
           background: 'transparent',
           border: 'none',
-          color: 'inherit',
           font: 'inherit',
-          cursor: 'pointer',
           fontWeight: 600,
+          cursor: 'pointer',
         }}
       >
-        <span>Legend</span>
+        <span>{title}</span>
         <span aria-hidden="true" style={{ fontSize: 10, opacity: 0.7 }}>
           {open ? '▾' : '▸'}
         </span>
@@ -62,7 +63,7 @@ function LegendRow({ swatch, label }: { swatch: React.ReactNode; label: string }
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
       {swatch}
-      <span>{label}</span>
+      <span className="graph-panel-label">{label}</span>
     </div>
   );
 }
@@ -71,16 +72,18 @@ function Swatch({ borderStyle, muted = false }: { borderStyle: 'solid' | 'dashed
   return (
     <span
       aria-hidden="true"
+      className="graph-legend-swatch"
       style={{
         display: 'inline-block',
         width: 20,
         height: 14,
-        border: `2px ${borderStyle} ${muted ? '#94a3b8' : '#64748b'}`,
+        borderWidth: 2,
+        borderStyle,
         borderRadius: 3,
-        background: 'var(--legend-swatch-bg, #f8fafc)',
         opacity: muted ? 0.55 : 1,
         flexShrink: 0,
       }}
+      data-muted={muted ? 'true' : undefined}
     />
   );
 }
@@ -89,15 +92,16 @@ function CloudSwatch() {
   return (
     <span
       aria-hidden="true"
+      className="graph-legend-swatch graph-legend-cloud"
       style={{
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
         width: 20,
         height: 14,
-        border: '1px solid #64748b',
+        borderWidth: 1,
+        borderStyle: 'solid',
         borderRadius: 3,
-        color: '#64748b',
         flexShrink: 0,
       }}
     >

--- a/catalog-ui/src/styles/global.css
+++ b/catalog-ui/src/styles/global.css
@@ -266,6 +266,24 @@
   font-weight: 600;
 }
 
+/* Node-key swatches */
+.graph-legend-swatch {
+  background: #f8fafc;
+  border-color: #64748b;
+  color: #64748b;
+}
+.graph-legend-swatch[data-muted="true"] {
+  border-color: #94a3b8;
+}
+[data-theme="dark"] .graph-legend-swatch {
+  background: rgb(30 41 59);
+  border-color: #94a3b8;
+  color: #94a3b8;
+}
+[data-theme="dark"] .graph-legend-swatch[data-muted="true"] {
+  border-color: #64748b;
+}
+
 [data-theme="dark"] .graph-panel-box {
   background: rgb(15 23 42);
   border-color: rgb(51 65 85);


### PR DESCRIPTION
## Summary

Small polish on the graph node key shipped in #65:

- Renamed **"Legend" → "Node key"** — tighter, matches standard map/graph terminology
- Dark/light mode now works — the box previously stayed white in dark mode because it used custom CSS vars that weren't themed. Dropped the custom vars and reused the existing `graph-panel-box` / `graph-panel-heading` / `graph-panel-label` classes that already handle theme switching
- Added a `.graph-legend-swatch` rule so the status/sourcing swatches adapt in both themes

## Test plan

- [x] All 99 tests still pass
- [x] Astro build clean — 287 pages
- [x] Visually verified on dev server in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)