### PR TITLE
feat: add Piece 2 meta-model generator (draw.io → registry-mapping.yaml)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,11 @@ docs-site/                   # Starlight documentation site
 ## Key Scripts
 
 ```bash
-python scripts/validate.py              # Validate model
-python scripts/generate_dashboard.py    # Generate dashboard.html
-python scripts/refresh_diagrams.py      # Sync registry to diagrams
-python scripts/extract_view.py <file>   # Extract YAML from diagram
+python scripts/validate.py                            # Validate model
+python scripts/generate_dashboard.py                  # Generate dashboard.html
+python scripts/refresh_diagrams.py                    # Sync registry to diagrams
+python scripts/extract_view.py <file>                 # Extract YAML from diagram
+python scripts/generate_metamodel.py <file.drawio>    # Generate registry-mapping.yaml from meta-model diagram
 ```
 
 ---

--- a/models/meta-model-convention.md
+++ b/models/meta-model-convention.md
@@ -1,0 +1,111 @@
+# Meta-Model Diagram Convention
+
+This document defines how to draw a meta-model diagram in draw.io that can be parsed by `scripts/generate_metamodel.py` to generate `registry-mapping.yaml`.
+
+## Overview
+
+A meta-model diagram is a visual representation of your architecture vocabulary. It defines:
+- **Element types** (shapes) — the kinds of things in your architecture (e.g., Component, Service, Data Entity)
+- **Layers** (swimlanes/containers) — groupings of element types (e.g., Business, Application, Technology)
+- **Relationships** (arrows) — how element types connect (e.g., Component realizes Capability)
+
+## Drawing Convention
+
+### Layers (Swimlanes)
+
+Use **horizontal swimlanes** or **container rectangles** to represent layers.
+
+- **Label:** The layer name (e.g., "Business", "Application", "Technology")
+- **Style property `layer`:** Set to the layer key (e.g., `business`, `application`)
+- **Style property `layerColor`:** Hex color for the layer (e.g., `#3b82f6`)
+- **Style property `layerBg`:** Hex background color (e.g., `#eff6ff`)
+- **Style property `layerIcon`:** Single character icon (e.g., `B`, `A`, `T`)
+
+If style properties are not set, the script infers:
+- Layer key from the label (lowercased, spaces to underscores)
+- Color from a default palette
+- Icon from the first letter of the label
+
+### Element Types (Shapes)
+
+Use **rectangles** inside a layer swimlane. Each rectangle represents an element type.
+
+**Required properties** (set via draw.io shape label or custom properties):
+- **Label:** The element type display name (e.g., "Business Capability", "Software System")
+
+**Optional custom properties** (Edit → Edit Data in draw.io):
+- `key` — Element type key (e.g., `business_capability`). Auto-generated from label if omitted.
+- `icon` — Emoji icon (e.g., `🧩`). Defaults to a generic icon per layer.
+- `graph_rank` — Integer for left-to-right layout position. Auto-assigned if omitted.
+- `id_field` — Which frontmatter field is the file identity (default: `name`)
+- `folder` — Override the auto-generated folder path
+- `badge_category` — Badge grouping label (auto-generated from key if omitted)
+
+**Standard fields** (name, description, owner, domain, status) are added automatically to every element type. You only need to declare **extra fields** as child shapes or in custom properties:
+- `fields` — Comma-separated list of extra field definitions: `field_name:type:label` (e.g., `sourcing:string:Sourcing,maturity:string:Maturity`)
+
+### Relationships (Arrows)
+
+Use **arrows/connectors** between element type shapes to define relationships.
+
+**Arrow label:** The relationship field name on the source element (e.g., `realizes_components`, `composes_subsystems`)
+
+**Required custom properties** (Edit → Edit Data on the arrow):
+- `type` — Relationship type key (e.g., `composition`, `realization`, `serving`)
+
+**Optional custom properties:**
+- `cardinality` — `one` or `many` (default: `many`)
+- `resolve_by` — `slug`, `name`, or `abbreviation` (default: `name`)
+- `inverse` — Field name on the target that points back (e.g., `parent_domain`)
+- `required` — `true` or `false` (default: `false`)
+
+### Relationship Types
+
+Define relationship type semantics by placing a **table/list shape** anywhere on the canvas with the custom property `metamodel_type: relationship_types`.
+
+Each row defines: `key | outgoing_verb | incoming_verb | icon`
+
+Example:
+```
+composition | Composes | Part of | ◇
+realization | Realizes | Realized by | ▲
+serving     | Serves   | Served by   | →
+```
+
+If not present, the script uses ArchiMate-inspired defaults.
+
+## Example
+
+A minimal meta-model diagram might contain:
+
+```
+┌─── Business Layer ──────────────────────┐
+│  ┌──────────────┐  ┌──────────────────┐ │
+│  │ Product      │  │ Business Service │ │
+│  └──────────────┘  └──────────────────┘ │
+└─────────────────────────────────────────┘
+┌─── Application Layer ───────────────────┐
+│  ┌──────────┐  ┌──────────────┐        │
+│  │ Domain   │──│ Component    │────────→│→ Software System
+│  └──────────┘  └──────────────┘        │
+└─────────────────────────────────────────┘
+```
+
+With arrows labeled `composes_components` (Domain → Component, type: composition) and `realized_by_software_systems` (Component → Software System, type: realization).
+
+## Running the Generator
+
+```bash
+python scripts/generate_metamodel.py models/meta-model.drawio
+python scripts/generate_metamodel.py models/meta-model.drawio --output models/registry-mapping.yaml
+python scripts/generate_metamodel.py models/meta-model.drawio --validate  # Check without writing
+```
+
+## Output
+
+The script generates a complete `registry-mapping.yaml` with:
+- `version`, `registry_root`, `site` metadata
+- `layers` section from swimlanes
+- `relationship_types` section
+- `domain_color_palette` (default)
+- `elements` section with all types, fields, and relationships

--- a/models/meta-model-example.drawio
+++ b/models/meta-model-example.drawio
@@ -1,0 +1,133 @@
+<mxfile host="app.diagrams.net" agent="meta-model-generator" version="1.0">
+  <diagram id="meta-model" name="Meta-Model">
+    <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1200">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- ═══════════════════════════════════════════ -->
+        <!-- Layer: Business                             -->
+        <!-- ═══════════════════════════════════════════ -->
+        <mxCell id="layer-business" value="Business" style="swimlane;startSize=30;fillColor=#faf5ff;strokeColor=#a855f7;" vertex="1" parent="1">
+          <mxGraphModel><root>
+            <mxCell id="layer" value="business"/>
+            <mxCell id="layerColor" value="#a855f7"/>
+            <mxCell id="layerBg" value="#faf5ff"/>
+            <mxCell id="layerIcon" value="B"/>
+          </root></mxGraphModel>
+          <mxGeometry x="40" y="40" width="1520" height="200" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="el-product" value="Product" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-business">
+          <mxGeometry x="40" y="50" width="160" height="60" as="geometry"/>
+          <Object key="product" icon="📦" graph_rank="-1" badge_category="product" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-market-segment" value="Market Segment" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-business">
+          <mxGeometry x="260" y="50" width="160" height="60" as="geometry"/>
+          <Object key="market_segment" icon="👥" graph_rank="-2" badge_category="segment" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-business-service" value="Business Service" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-business">
+          <mxGeometry x="480" y="50" width="160" height="60" as="geometry"/>
+          <Object key="business_service" icon="🎁" graph_rank="-1" badge_category="service" as="customProperties"/>
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════ -->
+        <!-- Layer: Organization                         -->
+        <!-- ═══════════════════════════════════════════ -->
+        <mxCell id="layer-organization" value="Organization" style="swimlane;startSize=30;fillColor=#fffbeb;strokeColor=#f59e0b;" vertex="1" parent="1">
+          <mxGeometry x="40" y="280" width="1520" height="200" as="geometry"/>
+          <Object layer="organization" layerColor="#f59e0b" layerBg="#fffbeb" layerIcon="O" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-capability" value="Business Capability" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-organization">
+          <mxGeometry x="40" y="50" width="180" height="60" as="geometry"/>
+          <Object key="business_capability" icon="🎯" graph_rank="1" badge_category="capability" fields="maturity:string:Maturity,lifecycle:string:Lifecycle,sourcing:string:Sourcing,size:string:Size" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-process" value="Business Process" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-organization">
+          <mxGeometry x="280" y="50" width="180" height="60" as="geometry"/>
+          <Object key="business_process" icon="🔄" graph_rank="1" badge_category="process" fields="specialization:string:Specialization,value_stream:string:Value Stream" as="customProperties"/>
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════ -->
+        <!-- Layer: Application                          -->
+        <!-- ═══════════════════════════════════════════ -->
+        <mxCell id="layer-application" value="Application" style="swimlane;startSize=30;fillColor=#eff6ff;strokeColor=#3b82f6;" vertex="1" parent="1">
+          <mxGeometry x="40" y="520" width="1520" height="200" as="geometry"/>
+          <Object layer="application" layerColor="#3b82f6" layerBg="#eff6ff" layerIcon="A" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-domain" value="Domain" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-application">
+          <mxGeometry x="40" y="50" width="140" height="60" as="geometry"/>
+          <Object key="domain" icon="🏛️" graph_rank="0" badge_category="domain" fields="aliases:string[]:Aliases" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-component" value="Component" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-application">
+          <mxGeometry x="220" y="50" width="140" height="60" as="geometry"/>
+          <Object key="component" icon="🧩" graph_rank="1" badge_category="component" fields="sourcing:string:Sourcing" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-software-system" value="Software System" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-application">
+          <mxGeometry x="400" y="50" width="160" height="60" as="geometry"/>
+          <Object key="software_system" icon="🖥️" graph_rank="2" badge_category="system" fields="full_name:string:Full Name,abbreviation:string:Abbreviation,sourcing:string:Sourcing,catalog_id:string:Catalog ID,system_type:string:System Type,vendor:string:Vendor" as="customProperties"/>
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════ -->
+        <!-- Layer: Technology                           -->
+        <!-- ═══════════════════════════════════════════ -->
+        <mxCell id="layer-technology" value="Technology" style="swimlane;startSize=30;fillColor=#ecfdf5;strokeColor=#10b981;" vertex="1" parent="1">
+          <mxGeometry x="40" y="760" width="1520" height="200" as="geometry"/>
+          <Object layer="technology" layerColor="#10b981" layerBg="#ecfdf5" layerIcon="T" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-infra-node" value="Infrastructure Node" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-technology">
+          <mxGeometry x="40" y="50" width="180" height="60" as="geometry"/>
+          <Object key="infra_node" icon="🖧" graph_rank="4" badge_category="infrastructure" fields="node_type:string:Node Type,cloud_provider:string:Cloud Provider" as="customProperties"/>
+        </mxCell>
+
+        <mxCell id="el-cloud-service" value="Cloud Service" style="rounded=0;whiteSpace=wrap;" vertex="1" parent="layer-technology">
+          <mxGeometry x="280" y="50" width="160" height="60" as="geometry"/>
+          <Object key="cloud_service" icon="☁️" graph_rank="4" badge_category="infrastructure" fields="cloud_provider:string:Cloud Provider" as="customProperties"/>
+        </mxCell>
+
+        <!-- ═══════════════════════════════════════════ -->
+        <!-- Relationships (arrows)                      -->
+        <!-- ═══════════════════════════════════════════ -->
+
+        <!-- Product → Market Segment (serving) -->
+        <mxCell id="rel-1" value="serves_market_segments" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="el-product" target="el-market-segment" parent="1">
+          <Object type="serving" cardinality="many" resolve_by="name" inverse="served_by_products" required="false" as="customProperties"/>
+        </mxCell>
+
+        <!-- Product → Business Service (aggregation) -->
+        <mxCell id="rel-2" value="aggregates_business_services" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="el-product" target="el-business-service" parent="1">
+          <Object type="aggregation" cardinality="many" resolve_by="name" inverse="aggregated_by_product" required="false" as="customProperties"/>
+        </mxCell>
+
+        <!-- Domain → Component (composition) -->
+        <mxCell id="rel-3" value="composes_components" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="el-domain" target="el-component" parent="1">
+          <Object type="composition" cardinality="many" resolve_by="slug" inverse="parent_domain" required="false" as="customProperties"/>
+        </mxCell>
+
+        <!-- Component → Software System (realization) -->
+        <mxCell id="rel-4" value="realized_by_software_systems" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="el-component" target="el-software-system" parent="1">
+          <Object type="realization" cardinality="many" resolve_by="name" inverse="realizes_components" required="false" as="customProperties"/>
+        </mxCell>
+
+        <!-- Business Capability → Component (realization) -->
+        <mxCell id="rel-5" value="realized_by_components" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="el-capability" target="el-component" parent="1">
+          <Object type="realization" cardinality="many" resolve_by="name" inverse="realizes_business_capability" required="false" as="customProperties"/>
+        </mxCell>
+
+        <!-- Relationship Types table -->
+        <mxCell id="rel-types" value="Relationship Types" style="shape=table;startSize=30;" vertex="1" parent="1">
+          <mxGeometry x="1200" y="40" width="300" height="180" as="geometry"/>
+          <Object metamodel_type="relationship_types" data="composition|Composes|Part of|◇;aggregation|Owns|Owned by|◆;realization|Realizes|Realized by|▲;serving|Serves|Served by|→;assignment|Assigned to|Assigned from|⊕;access|Accesses|Accessed by|⊙" as="customProperties"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/scripts/generate_metamodel.py
+++ b/scripts/generate_metamodel.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""
+Meta-Model Generator — Piece 2
+
+Parses a draw.io meta-model diagram and generates registry-mapping.yaml.
+
+Convention: see models/meta-model-convention.md for how to draw the diagram.
+
+Usage:
+    python scripts/generate_metamodel.py <path-to.drawio>
+    python scripts/generate_metamodel.py <path-to.drawio> --output models/registry-mapping.yaml
+    python scripts/generate_metamodel.py <path-to.drawio> --validate
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# ─────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────
+
+DEFAULT_LAYERS_PALETTE = [
+    {"color": "#a855f7", "bg": "#faf5ff", "icon": "B"},
+    {"color": "#f59e0b", "bg": "#fffbeb", "icon": "O"},
+    {"color": "#3b82f6", "bg": "#eff6ff", "icon": "A"},
+    {"color": "#10b981", "bg": "#ecfdf5", "icon": "T"},
+]
+
+DEFAULT_DOMAIN_PALETTE = [
+    "#3b82f6", "#8b5cf6", "#ec4899", "#f59e0b", "#06b6d4",
+    "#84cc16", "#f97316", "#10b981", "#ef4444", "#6366f1",
+]
+
+DEFAULT_RELATIONSHIP_TYPES: dict[str, dict[str, str]] = {
+    "composition": {"outgoing": "Composes", "incoming": "Part of", "icon": "◇"},
+    "aggregation": {"outgoing": "Owns", "incoming": "Owned by", "icon": "◆"},
+    "realization": {"outgoing": "Realizes", "incoming": "Realized by", "icon": "▲"},
+    "serving": {"outgoing": "Serves", "incoming": "Served by", "icon": "→"},
+    "assignment": {"outgoing": "Assigned to", "incoming": "Assigned from", "icon": "⊕"},
+    "access": {"outgoing": "Accesses", "incoming": "Accessed by", "icon": "⊙"},
+}
+
+STANDARD_FIELDS: dict[str, dict[str, Any]] = {
+    "type": {"type": "string", "required": False, "label": "Element Type"},
+    "name": {"type": "string", "required": True, "label": "Name"},
+    "description": {"type": "string", "required": False, "label": "Description"},
+    "owner": {"type": "string", "required": False, "label": "Owner"},
+    "domain": {"type": "string", "required": False, "label": "Domain"},
+    "status": {"type": "string", "required": False, "label": "Status"},
+}
+
+DEFAULT_ICONS = {"B": "📋", "O": "🎯", "A": "🧩", "T": "🖧"}
+
+
+# ─────────────────────────────────────────────────────────────
+# Parsing
+# ─────────────────────────────────────────────────────────────
+
+def label_to_key(label: str) -> str:
+    """Convert a human label to a snake_case key."""
+    key = label.strip().lower()
+    key = re.sub(r"[^a-z0-9]+", "_", key)
+    return key.strip("_")
+
+
+def label_to_folder_segment(label: str) -> str:
+    """Convert a human label to a kebab-case folder segment."""
+    segment = label.strip().lower()
+    segment = re.sub(r"[^a-z0-9]+", "-", segment)
+    return segment.strip("-") + "s"  # pluralize
+
+
+def get_custom_property(cell: ET.Element, prop_name: str) -> str | None:
+    """Extract a custom property from a cell's Object child."""
+    obj = cell.find("Object[@as='customProperties']")
+    if obj is not None:
+        return obj.get(prop_name)
+    # Also check for inline attributes on the cell
+    return cell.get(prop_name)
+
+
+def get_custom_properties(cell: ET.Element) -> dict[str, str]:
+    """Extract all custom properties from a cell."""
+    props: dict[str, str] = {}
+    obj = cell.find("Object[@as='customProperties']")
+    if obj is not None:
+        for key, val in obj.attrib.items():
+            if key != "as":
+                props[key] = val
+    return props
+
+
+def parse_style(style_str: str) -> dict[str, str]:
+    """Parse draw.io style string into dict."""
+    props: dict[str, str] = {}
+    if not style_str:
+        return props
+    for part in style_str.split(";"):
+        if "=" in part:
+            k, v = part.split("=", 1)
+            props[k.strip()] = v.strip()
+        elif part.strip():
+            props[part.strip()] = "true"
+    return props
+
+
+# ─────────────────────────────────────────────────────────────
+# Core extraction
+# ─────────────────────────────────────────────────────────────
+
+def extract_metamodel(drawio_path: Path) -> dict[str, Any]:
+    """Parse a draw.io meta-model and return structured data."""
+    tree = ET.parse(drawio_path)
+    root = tree.getroot()
+
+    diagram = root.find(".//diagram")
+    if diagram is None:
+        raise ValueError("No <diagram> element found in draw.io file")
+
+    model = diagram.find(".//mxGraphModel")
+    if model is None:
+        raise ValueError("No <mxGraphModel> found in diagram")
+
+    cells = model.findall(".//mxCell")
+
+    # Categorize cells
+    layers: dict[str, dict[str, Any]] = {}
+    elements: dict[str, dict[str, Any]] = {}
+    relationships: list[dict[str, Any]] = []
+    relationship_types: dict[str, dict[str, str]] = {}
+    cell_parent_map: dict[str, str] = {}
+
+    # First pass: identify all cells and their parents
+    for cell in cells:
+        cell_id = cell.get("id", "")
+        parent_id = cell.get("parent", "")
+        cell_parent_map[cell_id] = parent_id
+
+    # Second pass: identify layers (swimlanes)
+    for cell in cells:
+        cell_id = cell.get("id", "")
+        style_str = cell.get("style", "")
+        style = parse_style(style_str)
+        value = cell.get("value", "")
+
+        if "swimlane" in style or "swimlane" in style_str:
+            props = get_custom_properties(cell)
+            layer_key = props.get("layer", label_to_key(value))
+            layer_idx = len(layers)
+            palette = DEFAULT_LAYERS_PALETTE[layer_idx] if layer_idx < len(DEFAULT_LAYERS_PALETTE) else {}
+
+            layers[cell_id] = {
+                "key": layer_key,
+                "name": value,
+                "color": props.get("layerColor", style.get("strokeColor", palette.get("color", "#666"))),
+                "bg": props.get("layerBg", style.get("fillColor", palette.get("bg", "#f5f5f5"))),
+                "icon": props.get("layerIcon", palette.get("icon", value[0] if value else "?")),
+            }
+
+    # Third pass: identify element types (non-edge cells inside layers)
+    for cell in cells:
+        cell_id = cell.get("id", "")
+        parent_id = cell.get("parent", "")
+        is_edge = cell.get("edge") == "1"
+        value = cell.get("value", "").strip()
+
+        if is_edge or not value or cell_id in ("0", "1"):
+            continue
+
+        # Check if this cell is a relationship types table
+        props = get_custom_properties(cell)
+        if props.get("metamodel_type") == "relationship_types":
+            data = props.get("data", "")
+            for row in data.split(";"):
+                parts = [p.strip() for p in row.split("|")]
+                if len(parts) >= 4:
+                    relationship_types[parts[0]] = {
+                        "outgoing": parts[1],
+                        "incoming": parts[2],
+                        "icon": parts[3],
+                    }
+            continue
+
+        # Skip if it's a layer itself
+        if cell_id in layers:
+            continue
+
+        # Check if parent is a layer
+        if parent_id not in layers:
+            continue
+
+        # This is an element type
+        layer_info = layers[parent_id]
+        key = props.get("key", label_to_key(value))
+        icon = props.get("icon", DEFAULT_ICONS.get(layer_info["icon"], "📋"))
+        graph_rank = int(props.get("graph_rank", "1"))
+        badge_category = props.get("badge_category", key.split("_")[-1] if "_" in key else key)
+        id_field = props.get("id_field", "name")
+
+        # Parse extra fields
+        extra_fields: dict[str, dict[str, Any]] = {}
+        fields_str = props.get("fields", "")
+        if fields_str:
+            for field_def in fields_str.split(","):
+                parts = [p.strip() for p in field_def.split(":")]
+                if len(parts) >= 3:
+                    extra_fields[parts[0]] = {
+                        "type": parts[1],
+                        "required": False,
+                        "label": parts[2],
+                    }
+                elif len(parts) == 2:
+                    extra_fields[parts[0]] = {
+                        "type": parts[1],
+                        "required": False,
+                        "label": parts[0].replace("_", " ").title(),
+                    }
+
+        # Auto-generate folder path
+        layer_key = layer_info["key"]
+        layer_number = list(layers.values()).index(layer_info) + 1
+        folder_prefix = f"{layer_number}-{layer_key}"
+        folder_segment = props.get("folder", f"{folder_prefix}/{label_to_folder_segment(value)}")
+
+        elements[cell_id] = {
+            "key": key,
+            "label": value,
+            "layer": layer_key,
+            "folder": folder_segment,
+            "id_field": id_field,
+            "graph_rank": graph_rank,
+            "icon": icon,
+            "badge_category": badge_category,
+            "extra_fields": extra_fields,
+            "relationships": {},
+        }
+
+    # Fourth pass: extract relationships (edges)
+    for cell in cells:
+        if cell.get("edge") != "1":
+            continue
+
+        source_id = cell.get("source", "")
+        target_id = cell.get("target", "")
+        value = cell.get("value", "").strip()
+
+        if not source_id or not target_id or not value:
+            continue
+
+        props = get_custom_properties(cell)
+        rel_type = props.get("type", "serving")
+        cardinality = props.get("cardinality", "many")
+        resolve_by = props.get("resolve_by", "name")
+        inverse = props.get("inverse", "~")
+        required = props.get("required", "false").lower() == "true"
+
+        if source_id in elements and target_id in elements:
+            target_key = elements[target_id]["key"]
+            elements[source_id]["relationships"][value] = {
+                "target": target_key,
+                "type": rel_type,
+                "cardinality": cardinality,
+                "resolve_by": resolve_by,
+                "inverse": inverse if inverse != "~" else "~",
+                "required": required,
+            }
+
+    # Use defaults if no relationship types defined
+    if not relationship_types:
+        relationship_types = DEFAULT_RELATIONSHIP_TYPES
+
+    return {
+        "layers": {info["key"]: info for info in layers.values()},
+        "elements": {info["key"]: info for info in elements.values()},
+        "relationship_types": relationship_types,
+    }
+
+
+# ─────────────────────────────────────────────────────────────
+# YAML generation
+# ─────────────────────────────────────────────────────────────
+
+def generate_yaml(metamodel: dict[str, Any]) -> dict[str, Any]:
+    """Convert extracted meta-model to registry-mapping.yaml structure."""
+    output: dict[str, Any] = {
+        "version": "1.0",
+        "registry_root": "registry-v2",
+    }
+
+    # Site metadata
+    output["site"] = {
+        "name": "Architecture Catalog",
+        "company": "Your Company",
+        "description": "Enterprise architecture registry",
+        "logo_text": "A",
+    }
+
+    # Layers
+    layers_section: dict[str, Any] = {}
+    for key, info in metamodel["layers"].items():
+        layers_section[key] = {
+            "name": info["name"],
+            "color": f'"{info["color"]}"',
+            "bg": f'"{info["bg"]}"',
+            "icon": info["icon"],
+        }
+    output["layers"] = layers_section
+
+    # Relationship types
+    output["relationship_types"] = metamodel["relationship_types"]
+
+    # Domain color palette
+    output["domain_color_palette"] = DEFAULT_DOMAIN_PALETTE
+
+    # Elements
+    elements_section: dict[str, Any] = {}
+    for key, info in metamodel["elements"].items():
+        # Build fields: standard + extra
+        fields: dict[str, Any] = {}
+        for fname, fdef in STANDARD_FIELDS.items():
+            # Skip domain field for domain-anchor elements (graph_rank 0)
+            if fname == "domain" and info["graph_rank"] == 0:
+                continue
+            fields[fname] = dict(fdef)
+
+        for fname, fdef in info["extra_fields"].items():
+            fields[fname] = dict(fdef)
+
+        # Build relationships
+        relationships: dict[str, Any] = {}
+        for rel_name, rel_info in info["relationships"].items():
+            rel_entry: dict[str, Any] = {
+                "target": rel_info["target"],
+                "type": rel_info["type"],
+                "cardinality": rel_info["cardinality"],
+                "resolve_by": rel_info["resolve_by"],
+                "inverse": rel_info["inverse"],
+                "required": rel_info["required"],
+            }
+            relationships[rel_name] = rel_entry
+
+        element_entry: dict[str, Any] = {
+            "label": info["label"],
+            "layer": info["layer"],
+            "folder": info["folder"],
+            "id_field": info["id_field"],
+            "graph_rank": info["graph_rank"],
+            "icon": info["icon"],
+            "badge_category": info["badge_category"],
+            "fields": fields,
+        }
+        if relationships:
+            element_entry["relationships"] = relationships
+
+        elements_section[key] = element_entry
+
+    output["elements"] = elements_section
+    return output
+
+
+# ─────────────────────────────────────────────────────────────
+# Validation
+# ─────────────────────────────────────────────────────────────
+
+def validate_metamodel(metamodel: dict[str, Any]) -> list[str]:
+    """Validate the extracted meta-model and return list of issues."""
+    issues: list[str] = []
+
+    if not metamodel["layers"]:
+        issues.append("No layers found. Use swimlane shapes to define layers.")
+
+    if not metamodel["elements"]:
+        issues.append("No element types found. Place rectangle shapes inside layer swimlanes.")
+
+    # Check for elements without layers
+    known_layers = set(metamodel["layers"].keys())
+    for key, info in metamodel["elements"].items():
+        if info["layer"] not in known_layers:
+            issues.append(f"Element '{key}' references unknown layer '{info['layer']}'")
+
+    # Check for relationships pointing to unknown targets
+    known_elements = set(metamodel["elements"].keys())
+    for key, info in metamodel["elements"].items():
+        for rel_name, rel_info in info["relationships"].items():
+            if rel_info["target"] not in known_elements:
+                issues.append(
+                    f"Element '{key}' relationship '{rel_name}' targets "
+                    f"unknown element '{rel_info['target']}'"
+                )
+
+    # Check for graph_rank 0 (domain anchor)
+    has_anchor = any(
+        info["graph_rank"] == 0 for info in metamodel["elements"].values()
+    )
+    if metamodel["elements"] and not has_anchor:
+        issues.append(
+            "No element with graph_rank=0 found. One element should be the domain anchor."
+        )
+
+    # Check for duplicate keys
+    keys = [info["key"] for info in metamodel["elements"].values()]
+    dupes = [k for k in set(keys) if keys.count(k) > 1]
+    if dupes:
+        issues.append(f"Duplicate element keys: {', '.join(dupes)}")
+
+    return issues
+
+
+# ─────────────────────────────────────────────────────────────
+# Output
+# ─────────────────────────────────────────────────────────────
+
+def write_yaml(data: dict[str, Any], output_path: Path) -> None:
+    """Write the registry-mapping YAML to a file."""
+
+    class QuotedStr(str):
+        """String that should be quoted in YAML output."""
+
+    def quoted_representer(dumper: yaml.Dumper, data: QuotedStr) -> yaml.Node:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
+
+    yaml.add_representer(QuotedStr, quoted_representer)
+
+    # Process the data to handle quoted strings (colors)
+    def process_values(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            result = {}
+            for k, v in obj.items():
+                if isinstance(v, str) and v.startswith('"') and v.endswith('"'):
+                    result[k] = QuotedStr(v[1:-1])
+                else:
+                    result[k] = process_values(v)
+            return result
+        if isinstance(obj, list):
+            return [process_values(item) for item in obj]
+        return obj
+
+    processed = process_values(data)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, "w") as f:
+        yaml.dump(
+            processed,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            width=120,
+        )
+
+    print(f"Generated: {output_path}")
+
+
+def print_summary(metamodel: dict[str, Any]) -> None:
+    """Print a human-readable summary of the meta-model."""
+    print("\n── Meta-Model Summary ──────────────────────────")
+    print(f"Layers:             {len(metamodel['layers'])}")
+    print(f"Element types:      {len(metamodel['elements'])}")
+    print(f"Relationship types: {len(metamodel['relationship_types'])}")
+
+    total_rels = sum(
+        len(info["relationships"]) for info in metamodel["elements"].values()
+    )
+    print(f"Relationships:      {total_rels}")
+
+    print("\nLayers:")
+    for key, info in metamodel["layers"].items():
+        print(f"  {info['icon']} {info['name']} ({key})")
+
+    print("\nElement types:")
+    for key, info in metamodel["elements"].items():
+        rel_count = len(info["relationships"])
+        extra = len(info["extra_fields"])
+        print(
+            f"  {info['icon']} {info['label']} ({key}) "
+            f"— rank {info['graph_rank']}, "
+            f"{6 + extra} fields, {rel_count} relationships"
+        )
+
+    print("───────────────────────────────────────────────\n")
+
+
+# ─────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate registry-mapping.yaml from a draw.io meta-model diagram"
+    )
+    parser.add_argument("drawio", type=Path, help="Path to the .drawio meta-model file")
+    parser.add_argument(
+        "--output", "-o", type=Path, default=None,
+        help="Output path (default: <input>.generated.yaml)"
+    )
+    parser.add_argument(
+        "--validate", action="store_true",
+        help="Validate only — don't write output"
+    )
+    args = parser.parse_args()
+
+    if not args.drawio.exists():
+        print(f"Error: File not found: {args.drawio}", file=sys.stderr)
+        return 1
+
+    try:
+        metamodel = extract_metamodel(args.drawio)
+    except (ET.ParseError, ValueError) as e:
+        print(f"Error parsing diagram: {e}", file=sys.stderr)
+        return 1
+
+    # Validate
+    issues = validate_metamodel(metamodel)
+    if issues:
+        print("\nValidation issues:", file=sys.stderr)
+        for issue in issues:
+            print(f"  ⚠️  {issue}", file=sys.stderr)
+
+    print_summary(metamodel)
+
+    if args.validate:
+        if issues:
+            print("Validation failed with issues above.", file=sys.stderr)
+            return 1
+        print("Validation passed.")
+        return 0
+
+    # Generate YAML
+    yaml_data = generate_yaml(metamodel)
+    output_path = args.output or args.drawio.with_suffix(".generated.yaml")
+    write_yaml(yaml_data, output_path)
+
+    if issues:
+        print(
+            f"\nGenerated with {len(issues)} warning(s). Review before using.",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_generate_metamodel.py
+++ b/scripts/tests/test_generate_metamodel.py
@@ -1,0 +1,222 @@
+"""Tests for generate_metamodel.py — Piece 2 meta-model generator."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts dir to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from generate_metamodel import (
+    extract_metamodel,
+    generate_yaml,
+    label_to_folder_segment,
+    label_to_key,
+    validate_metamodel,
+)
+
+
+EXAMPLE_DIAGRAM = Path(__file__).resolve().parent.parent.parent / "models" / "meta-model-example.drawio"
+
+
+# ─────────────────────────────────────────────────────────────
+# Unit tests: label_to_key
+# ─────────────────────────────────────────────────────────────
+
+class TestLabelToKey:
+    def test_simple(self) -> None:
+        assert label_to_key("Component") == "component"
+
+    def test_multi_word(self) -> None:
+        assert label_to_key("Business Capability") == "business_capability"
+
+    def test_special_chars(self) -> None:
+        assert label_to_key("API Endpoint (v2)") == "api_endpoint_v2"
+
+    def test_leading_trailing_spaces(self) -> None:
+        assert label_to_key("  Domain  ") == "domain"
+
+
+# ─────────────────────────────────────────────────────────────
+# Unit tests: label_to_folder_segment
+# ─────────────────────────────────────────────────────────────
+
+class TestLabelToFolderSegment:
+    def test_simple(self) -> None:
+        assert label_to_folder_segment("Component") == "components"
+
+    def test_multi_word(self) -> None:
+        assert label_to_folder_segment("Software System") == "software-systems"
+
+    def test_pluralizes(self) -> None:
+        assert label_to_folder_segment("Domain") == "domains"
+
+
+# ─────────────────────────────────────────────────────────────
+# Integration tests: example diagram parsing
+# ─────────────────────────────────────────────────────────────
+
+class TestExampleDiagram:
+    @pytest.fixture()
+    def metamodel(self) -> dict:
+        assert EXAMPLE_DIAGRAM.exists(), f"Example diagram not found: {EXAMPLE_DIAGRAM}"
+        return extract_metamodel(EXAMPLE_DIAGRAM)
+
+    def test_layers_count(self, metamodel: dict) -> None:
+        assert len(metamodel["layers"]) == 4
+
+    def test_layer_keys(self, metamodel: dict) -> None:
+        keys = set(metamodel["layers"].keys())
+        assert keys == {"business", "organization", "application", "technology"}
+
+    def test_layer_properties(self, metamodel: dict) -> None:
+        biz = metamodel["layers"]["business"]
+        assert biz["name"] == "Business"
+        assert biz["color"] == "#a855f7"
+        assert biz["icon"] == "B"
+
+    def test_element_count(self, metamodel: dict) -> None:
+        assert len(metamodel["elements"]) == 10
+
+    def test_element_keys(self, metamodel: dict) -> None:
+        keys = set(metamodel["elements"].keys())
+        assert "domain" in keys
+        assert "component" in keys
+        assert "software_system" in keys
+
+    def test_domain_is_anchor(self, metamodel: dict) -> None:
+        domain = metamodel["elements"]["domain"]
+        assert domain["graph_rank"] == 0
+
+    def test_extra_fields(self, metamodel: dict) -> None:
+        cap = metamodel["elements"]["business_capability"]
+        assert "maturity" in cap["extra_fields"]
+        assert "sourcing" in cap["extra_fields"]
+
+    def test_relationships(self, metamodel: dict) -> None:
+        domain = metamodel["elements"]["domain"]
+        assert "composes_components" in domain["relationships"]
+        rel = domain["relationships"]["composes_components"]
+        assert rel["target"] == "component"
+        assert rel["type"] == "composition"
+
+    def test_relationship_types(self, metamodel: dict) -> None:
+        assert "composition" in metamodel["relationship_types"]
+        assert "realization" in metamodel["relationship_types"]
+        comp = metamodel["relationship_types"]["composition"]
+        assert comp["outgoing"] == "Composes"
+        assert comp["incoming"] == "Part of"
+
+    def test_relationship_inverse(self, metamodel: dict) -> None:
+        domain = metamodel["elements"]["domain"]
+        rel = domain["relationships"]["composes_components"]
+        assert rel["inverse"] == "parent_domain"
+
+
+# ─────────────────────────────────────────────────────────────
+# Validation tests
+# ─────────────────────────────────────────────────────────────
+
+class TestValidation:
+    def test_valid_diagram_passes(self) -> None:
+        metamodel = extract_metamodel(EXAMPLE_DIAGRAM)
+        issues = validate_metamodel(metamodel)
+        assert len(issues) == 0
+
+    def test_empty_layers(self) -> None:
+        metamodel = {"layers": {}, "elements": {}, "relationship_types": {}}
+        issues = validate_metamodel(metamodel)
+        assert any("No layers" in i for i in issues)
+
+    def test_empty_elements(self) -> None:
+        metamodel = {
+            "layers": {"app": {"name": "App"}},
+            "elements": {},
+            "relationship_types": {},
+        }
+        issues = validate_metamodel(metamodel)
+        assert any("No element types" in i for i in issues)
+
+    def test_unknown_layer_reference(self) -> None:
+        metamodel = {
+            "layers": {"app": {"name": "App"}},
+            "elements": {
+                "comp": {
+                    "key": "comp",
+                    "label": "Component",
+                    "layer": "nonexistent",
+                    "graph_rank": 0,
+                    "extra_fields": {},
+                    "relationships": {},
+                }
+            },
+            "relationship_types": {},
+        }
+        issues = validate_metamodel(metamodel)
+        assert any("unknown layer" in i for i in issues)
+
+    def test_unknown_relationship_target(self) -> None:
+        metamodel = {
+            "layers": {"app": {"name": "App"}},
+            "elements": {
+                "comp": {
+                    "key": "comp",
+                    "label": "Component",
+                    "layer": "app",
+                    "graph_rank": 0,
+                    "extra_fields": {},
+                    "relationships": {
+                        "uses_thing": {
+                            "target": "nonexistent",
+                            "type": "serving",
+                        }
+                    },
+                }
+            },
+            "relationship_types": {},
+        }
+        issues = validate_metamodel(metamodel)
+        assert any("unknown element" in i for i in issues)
+
+
+# ─────────────────────────────────────────────────────────────
+# YAML generation tests
+# ─────────────────────────────────────────────────────────────
+
+class TestYamlGeneration:
+    def test_generates_valid_structure(self) -> None:
+        metamodel = extract_metamodel(EXAMPLE_DIAGRAM)
+        yaml_data = generate_yaml(metamodel)
+
+        assert yaml_data["version"] == "1.0"
+        assert yaml_data["registry_root"] == "registry-v2"
+        assert "layers" in yaml_data
+        assert "elements" in yaml_data
+        assert "relationship_types" in yaml_data
+        assert "domain_color_palette" in yaml_data
+        assert "site" in yaml_data
+
+    def test_elements_have_standard_fields(self) -> None:
+        metamodel = extract_metamodel(EXAMPLE_DIAGRAM)
+        yaml_data = generate_yaml(metamodel)
+
+        for key, element in yaml_data["elements"].items():
+            fields = element["fields"]
+            assert "name" in fields
+            assert "type" in fields
+            assert "status" in fields
+
+    def test_domain_anchor_skips_domain_field(self) -> None:
+        metamodel = extract_metamodel(EXAMPLE_DIAGRAM)
+        yaml_data = generate_yaml(metamodel)
+
+        domain_el = yaml_data["elements"]["domain"]
+        assert "domain" not in domain_el["fields"]
+
+    def test_non_anchor_has_domain_field(self) -> None:
+        metamodel = extract_metamodel(EXAMPLE_DIAGRAM)
+        yaml_data = generate_yaml(metamodel)
+
+        comp_el = yaml_data["elements"]["component"]
+        assert "domain" in comp_el["fields"]


### PR DESCRIPTION
## Summary
- Adds `scripts/generate_metamodel.py` — parses a draw.io meta-model diagram and generates `registry-mapping.yaml`
- Supports layers (swimlanes), element types (shapes with custom properties), relationships (arrows), and relationship type definitions
- Includes `--validate` mode for checking without writing
- Convention documentation in `models/meta-model-convention.md`
- Example draw.io diagram in `models/meta-model-example.drawio`
- 26 pytest tests covering parsing, validation, and YAML generation

## Test plan
- [x] `python scripts/generate_metamodel.py models/meta-model-example.drawio --validate` passes
- [x] Generated YAML matches expected registry-mapping.yaml structure
- [x] 26/26 pytest tests pass
- [ ] Verify generated YAML can be consumed by registry-loader.ts (build catalog-ui)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)